### PR TITLE
fix(auth): fall back to in-memory storage when localStorage is blocked

### DIFF
--- a/packages/auth/src/react/HerculesAuthProvider.test.tsx
+++ b/packages/auth/src/react/HerculesAuthProvider.test.tsx
@@ -12,10 +12,17 @@ const originalLocalStorage = Object.getOwnPropertyDescriptor(
   window,
   "localStorage",
 );
+const originalSessionStorage = Object.getOwnPropertyDescriptor(
+  window,
+  "sessionStorage",
+);
 
 afterEach(() => {
   if (originalLocalStorage) {
     Object.defineProperty(window, "localStorage", originalLocalStorage);
+  }
+  if (originalSessionStorage) {
+    Object.defineProperty(window, "sessionStorage", originalSessionStorage);
   }
   vi.restoreAllMocks();
 });
@@ -63,6 +70,72 @@ describe("HerculesAuthProvider", () => {
           length: 0,
         } as unknown as Storage;
       },
+    });
+
+    expect(() =>
+      render(
+        <HerculesAuthProvider
+          authority="https://example.com"
+          client_id="client-id"
+        >
+          <div>child</div>
+        </HerculesAuthProvider>,
+      ),
+    ).not.toThrow();
+  });
+
+  it("falls back to sessionStorage when localStorage is blocked", () => {
+    Object.defineProperty(window, "localStorage", {
+      configurable: true,
+      get() {
+        throw new DOMException("The operation is insecure.", "SecurityError");
+      },
+    });
+
+    const sessionSetItem = vi.fn();
+    const sessionRemoveItem = vi.fn();
+    Object.defineProperty(window, "sessionStorage", {
+      configurable: true,
+      get() {
+        return {
+          setItem: sessionSetItem,
+          getItem() {
+            return null;
+          },
+          removeItem: sessionRemoveItem,
+          clear() {},
+          key() {
+            return null;
+          },
+          length: 0,
+        } as unknown as Storage;
+      },
+    });
+
+    render(
+      <HerculesAuthProvider
+        authority="https://example.com"
+        client_id="client-id"
+      >
+        <div>child</div>
+      </HerculesAuthProvider>,
+    );
+
+    expect(sessionSetItem).toHaveBeenCalledWith("__hercules_auth_probe__", "1");
+    expect(sessionRemoveItem).toHaveBeenCalledWith("__hercules_auth_probe__");
+  });
+
+  it("renders children when both localStorage and sessionStorage are blocked", () => {
+    const throwSecurityError = () => {
+      throw new DOMException("The operation is insecure.", "SecurityError");
+    };
+    Object.defineProperty(window, "localStorage", {
+      configurable: true,
+      get: throwSecurityError,
+    });
+    Object.defineProperty(window, "sessionStorage", {
+      configurable: true,
+      get: throwSecurityError,
     });
 
     expect(() =>

--- a/packages/auth/src/react/HerculesAuthProvider.test.tsx
+++ b/packages/auth/src/react/HerculesAuthProvider.test.tsx
@@ -1,0 +1,79 @@
+import { describe, it, expect, vi, afterEach } from "vitest";
+import { render } from "@testing-library/react";
+import { HerculesAuthProvider } from "./HerculesAuthProvider.js";
+
+vi.mock("react-oidc-context", () => ({
+  AuthProvider: ({ children }: { children: React.ReactNode }) => (
+    <>{children}</>
+  ),
+}));
+
+const originalLocalStorage = Object.getOwnPropertyDescriptor(
+  window,
+  "localStorage",
+);
+
+afterEach(() => {
+  if (originalLocalStorage) {
+    Object.defineProperty(window, "localStorage", originalLocalStorage);
+  }
+  vi.restoreAllMocks();
+});
+
+describe("HerculesAuthProvider", () => {
+  it("renders children when localStorage access throws SecurityError", () => {
+    Object.defineProperty(window, "localStorage", {
+      configurable: true,
+      get() {
+        throw new DOMException("The operation is insecure.", "SecurityError");
+      },
+    });
+
+    expect(() =>
+      render(
+        <HerculesAuthProvider
+          authority="https://example.com"
+          client_id="client-id"
+        >
+          <div>child</div>
+        </HerculesAuthProvider>,
+      ),
+    ).not.toThrow();
+  });
+
+  it("renders children when localStorage methods throw SecurityError", () => {
+    Object.defineProperty(window, "localStorage", {
+      configurable: true,
+      get() {
+        return {
+          setItem() {
+            throw new DOMException(
+              "The operation is insecure.",
+              "SecurityError",
+            );
+          },
+          getItem() {
+            return null;
+          },
+          removeItem() {},
+          clear() {},
+          key() {
+            return null;
+          },
+          length: 0,
+        } as unknown as Storage;
+      },
+    });
+
+    expect(() =>
+      render(
+        <HerculesAuthProvider
+          authority="https://example.com"
+          client_id="client-id"
+        >
+          <div>child</div>
+        </HerculesAuthProvider>,
+      ),
+    ).not.toThrow();
+  });
+});

--- a/packages/auth/src/react/HerculesAuthProvider.tsx
+++ b/packages/auth/src/react/HerculesAuthProvider.tsx
@@ -6,10 +6,28 @@ import {
   type AuthProviderUserManagerProps,
 } from "react-oidc-context";
 import {
+  InMemoryWebStorage,
   UserManager,
   WebStorageStateStore,
   type UserManagerSettings,
 } from "oidc-client-ts";
+
+function resolveStorage(
+  getStorage: () => Storage,
+): Storage | InMemoryWebStorage {
+  if (typeof window === "undefined") {
+    return new InMemoryWebStorage();
+  }
+  try {
+    const storage = getStorage();
+    const probeKey = "__hercules_auth_probe__";
+    storage.setItem(probeKey, "1");
+    storage.removeItem(probeKey);
+    return storage;
+  } catch {
+    return new InMemoryWebStorage();
+  }
+}
 
 export type HerculesAuthProviderProps = Omit<
   AuthProviderUserManagerProps,
@@ -64,7 +82,14 @@ export function HerculesAuthProvider({
           window.location.origin,
         userStore:
           userManagerSettings?.userStore ??
-          new WebStorageStateStore({ store: window.localStorage }),
+          new WebStorageStateStore({
+            store: resolveStorage(() => window.localStorage),
+          }),
+        stateStore:
+          userManagerSettings?.stateStore ??
+          new WebStorageStateStore({
+            store: resolveStorage(() => window.localStorage),
+          }),
       }),
   );
 

--- a/packages/auth/src/react/HerculesAuthProvider.tsx
+++ b/packages/auth/src/react/HerculesAuthProvider.tsx
@@ -13,20 +13,23 @@ import {
 } from "oidc-client-ts";
 
 function resolveStorage(
-  getStorage: () => Storage,
+  getStorageFns: Array<() => Storage>,
 ): Storage | InMemoryWebStorage {
   if (typeof window === "undefined") {
     return new InMemoryWebStorage();
   }
-  try {
-    const storage = getStorage();
-    const probeKey = "__hercules_auth_probe__";
-    storage.setItem(probeKey, "1");
-    storage.removeItem(probeKey);
-    return storage;
-  } catch {
-    return new InMemoryWebStorage();
+  for (const getStorage of getStorageFns) {
+    try {
+      const storage = getStorage();
+      const probeKey = "__hercules_auth_probe__";
+      storage.setItem(probeKey, "1");
+      storage.removeItem(probeKey);
+      return storage;
+    } catch {
+      continue;
+    }
   }
+  return new InMemoryWebStorage();
 }
 
 export type HerculesAuthProviderProps = Omit<
@@ -83,12 +86,18 @@ export function HerculesAuthProvider({
         userStore:
           userManagerSettings?.userStore ??
           new WebStorageStateStore({
-            store: resolveStorage(() => window.localStorage),
+            store: resolveStorage([
+              () => window.localStorage,
+              () => window.sessionStorage,
+            ]),
           }),
         stateStore:
           userManagerSettings?.stateStore ??
           new WebStorageStateStore({
-            store: resolveStorage(() => window.localStorage),
+            store: resolveStorage([
+              () => window.localStorage,
+              () => window.sessionStorage,
+            ]),
           }),
       }),
   );


### PR DESCRIPTION
https://linear.app/hercules-app/issue/CUS-80/securityerror-in-herculesauthprovider-localstorage

## Issue

`HerculesAuthProvider` threw `SecurityError: The operation is insecure` at render time when an app built on `@usehercules/auth` ran inside the Hercules App Builder iframe preview (and any other cross-origin partitioned iframe context, such as Firefox Enhanced Tracking Protection or Safari private mode).

## Root cause

The `useState` initializer constructs `new UserManager(...)` and, as part of the settings object, unconditionally reads `window.localStorage`:

```tsx
userStore:
  userManagerSettings?.userStore ??
  new WebStorageStateStore({ store: window.localStorage }),
```

In cross-origin iframes where the embedding page has blocked third-party storage, the `window.localStorage` property getter itself throws `SecurityError` synchronously. The throw happens inside the `useState` initializer, so React surfaces it as a render error.

In addition, the inner `UserManagerSettingsStore` / `OidcClientSettingsStore` constructors default `stateStore` to `new WebStorageStateStore({ store: window.localStorage })` when one is not provided. The original code only passed `userStore`, leaving the `stateStore` default path to hit `window.localStorage` again inside `new UserManager(...)`.

## Fix

Probe each storage target in a try/catch at construction time. If the access or a write probe throws, fall back to `InMemoryWebStorage` (already exported by `oidc-client-ts`). Pass `stateStore` explicitly as well so the `UserManager` constructor does not access `window.localStorage` on its own default path.

When storage is available (the normal case: app running on its own origin), the probe succeeds and persistence behavior is unchanged.

## Test plan

Added `packages/auth/src/react/HerculesAuthProvider.test.tsx` with two tests:

- Mocks `window.localStorage` getter to throw `SecurityError`. Verifies `HerculesAuthProvider` renders its children without throwing.
- Mocks `window.localStorage.setItem` to throw `SecurityError`. Verifies the same.

Both tests fail on `main` (reproducing the bug) and pass with the fix. Existing `auth-callback-hook` tests continue to pass (13/13 total in the `@usehercules/auth` package).

## Reported in

Hercules customer escalation CUS-80. App: `01kp9e7vxdhaqq52y3xg5j5jvm.hercules-dev.com` rendered inside the App Builder preview iframe.