### PR TITLE
feat: session replay package

### DIFF
--- a/packages/session-replay/package.json
+++ b/packages/session-replay/package.json
@@ -1,0 +1,48 @@
+{
+  "name": "@usehercules/session-replay",
+  "version": "0.1.0",
+  "description": "Session replay (rrweb) recorder for Hercules applications",
+  "author": "Hercules Team",
+  "license": "MIT",
+  "repository": {
+    "type": "git",
+    "url": "git+https://github.com/withzeusai/hercules-js.git",
+    "directory": "packages/session-replay"
+  },
+  "type": "module",
+  "main": "./dist/es/index.mjs",
+  "module": "./dist/es/index.mjs",
+  "types": "./dist/es/index.d.mts",
+  "exports": {
+    ".": "./dist/es/index.mjs",
+    "./types": "./dist/es/types.mjs",
+    "./schema": "./dist/es/schema.mjs",
+    "./utils": "./dist/es/utils.mjs",
+    "./package.json": "./package.json",
+    "./script": "./dist/browser/script-content.mjs"
+  },
+  "files": [
+    "dist",
+    "src",
+    "tsconfig.json",
+    "tsdown.config.ts"
+  ],
+  "publishConfig": {
+    "access": "public"
+  },
+  "scripts": {
+    "build": "tsdown && node scripts/generate-script-export.mjs",
+    "dev": "tsdown --watch",
+    "test": "exit 0"
+  },
+  "dependencies": {
+    "bowser": "^2.14.1",
+    "rrweb": "^2.0.0-alpha.4",
+    "ulid": "^3.0.2",
+    "zod": "^4.3.6"
+  },
+  "devDependencies": {
+    "tsdown": "^0.18.4",
+    "typescript": "^5.9.3"
+  }
+}

--- a/packages/session-replay/scripts/generate-script-export.mjs
+++ b/packages/session-replay/scripts/generate-script-export.mjs
@@ -1,0 +1,36 @@
+/**
+ * Post-build script to generate a module that exports the ESM script as a string.
+ * This allows bundlers (esbuild, Vite, etc.) to import the script content directly.
+ */
+
+import { readFileSync, writeFileSync } from "fs";
+import { dirname, join } from "path";
+import { fileURLToPath } from "url";
+
+const __dirname = dirname(fileURLToPath(import.meta.url));
+const distBrowserDir = join(__dirname, "../dist/browser");
+
+const esmContent = readFileSync(join(distBrowserDir, "auto-init.js"), "utf-8");
+
+const wrapperContent = `// Auto-generated - do not edit
+// This module exports the ESM session replay script as a string for embedding
+
+/** The minified ESM session replay script content */
+export const script = ${JSON.stringify(esmContent)};
+
+export default script;
+`;
+
+writeFileSync(join(distBrowserDir, "script-content.mjs"), wrapperContent);
+
+const dtsContent = `// Auto-generated - do not edit
+
+/** The minified ESM session replay script content */
+export declare const script: string;
+
+export default script;
+`;
+
+writeFileSync(join(distBrowserDir, "script-content.d.mts"), dtsContent);
+
+console.log("\u2713 Generated script-content.mjs and script-content.d.mts");

--- a/packages/session-replay/src/auto-init.ts
+++ b/packages/session-replay/src/auto-init.ts
@@ -1,0 +1,76 @@
+// ============================================================================
+// Auto-initialization for ES module script embedding
+// ============================================================================
+
+import { initSessionReplay, type SessionReplayInstance } from "./index";
+import { shouldRecord } from "./utils";
+
+declare global {
+  // eslint-disable-next-line @typescript-eslint/no-namespace
+  namespace hercules {
+    let sessionReplay: SessionReplayInstance | undefined;
+  }
+}
+
+function parseUrlConfig() {
+  try {
+    const params = new URL(import.meta.url).searchParams;
+    const sampleRateParam = params.get("sampleRate");
+    const sampleRate = sampleRateParam != null ? Number(sampleRateParam) : undefined;
+    return {
+      apiEndpoint: params.get("apiEndpoint") ?? undefined,
+      debug: params.has("debug") ? params.get("debug") === "true" : undefined,
+      userId: params.get("userId") ?? undefined,
+      sampleRate: Number.isFinite(sampleRate) ? sampleRate : undefined,
+      recordInIframes: params.has("recordInIframes")
+        ? params.get("recordInIframes") === "true"
+        : undefined,
+      recordInHeadless: params.has("recordInHeadless")
+        ? params.get("recordInHeadless") === "true"
+        : undefined,
+    };
+  } catch {
+    return {};
+  }
+}
+
+/**
+ * Auto-initialize from URL params.
+ *
+ * Usage:
+ * <script
+ *   type="module"
+ *   src="/_hercules/r.js?websiteId=xxx&organizationId=yyy&sampleRate=100">
+ * </script>
+ */
+(function autoInit() {
+  const g = globalThis as typeof globalThis & {
+    hercules?: { sessionReplay?: SessionReplayInstance };
+  };
+
+  if (typeof window === "undefined") {
+    console.warn("[@usehercules/session-replay] window is not defined");
+    return;
+  }
+
+  const config = parseUrlConfig();
+
+  if (!shouldRecord(config.sampleRate)) {
+    if (config.debug) {
+      console.log("[hercules/session-replay] skipped due to sample rate", config.sampleRate);
+    }
+    return;
+  }
+
+  const instance = initSessionReplay({
+    apiEndpoint: config.apiEndpoint ?? "/_hercules/r",
+    debug: config.debug ?? false,
+    sampleRate: config.sampleRate ?? 100,
+    userId: config.userId,
+    recordInIframes: config.recordInIframes ?? false,
+    recordInHeadless: config.recordInHeadless ?? false,
+  });
+
+  g.hercules = g.hercules ?? {};
+  g.hercules.sessionReplay = instance;
+})();

--- a/packages/session-replay/src/index.ts
+++ b/packages/session-replay/src/index.ts
@@ -1,0 +1,301 @@
+/**
+ * @usehercules/session-replay
+ * rrweb-based session replay recorder for Hercules applications.
+ */
+
+import { record } from "rrweb";
+import type { SessionReplayChunk, SessionReplayChunkMeta } from "./schema";
+
+type RrwebEvent = unknown;
+import type { SessionReplayConfig, SessionReplayInstance } from "./types";
+import {
+  getDeviceInfo,
+  getOrCreatePersistedSessionId,
+  getViewport,
+  isHeadlessBrowser,
+  isInsideIframe,
+} from "./utils";
+
+export type { SessionReplayConfig, SessionReplayInstance } from "./types";
+export type { SessionReplayChunk, SessionReplayChunkMeta, DeviceType } from "./schema";
+
+const DEFAULT_FLUSH_INTERVAL_MS = 10_000;
+const DEFAULT_CHECKOUT_INTERVAL_MS = 30_000;
+const DEFAULT_API_ENDPOINT = "/_hercules/r";
+
+export class SessionReplayRecorder {
+  private readonly apiEndpoint: string;
+  private readonly userId: string | undefined;
+  private readonly debug: boolean;
+  private readonly flushIntervalMs: number;
+  private readonly checkoutEveryNms: number;
+  private readonly maskAllInputs: boolean;
+  public readonly sessionId: string;
+
+  private buffer: RrwebEvent[] = [];
+  private chunkIndex = 0;
+  private flushTimer: ReturnType<typeof setInterval> | undefined;
+  private stopFn: (() => void) | undefined;
+  private chunkStartedAt: number;
+  private stopped = false;
+  private paused = false;
+
+  constructor(config: SessionReplayConfig) {
+    this.apiEndpoint = config.apiEndpoint ?? DEFAULT_API_ENDPOINT;
+    this.userId = config.userId;
+    this.debug = config.debug ?? false;
+    this.flushIntervalMs = config.flushIntervalMs ?? DEFAULT_FLUSH_INTERVAL_MS;
+    this.checkoutEveryNms = config.checkoutEveryNms ?? DEFAULT_CHECKOUT_INTERVAL_MS;
+    this.maskAllInputs = config.maskAllInputs ?? true;
+    this.sessionId = getOrCreatePersistedSessionId();
+    this.chunkStartedAt = Date.now();
+
+    if (typeof window === "undefined") {
+      if (this.debug) {
+        console.warn("[hercules/session-replay] window is not defined; skipping recorder.");
+      }
+      return;
+    }
+
+    // The Hercules dashboard renders the published app in a preview iframe,
+    // and we don't want that iframe (or any other embed) to spam recordings
+    // while developers are working on the app. Default to top-frame only;
+    // callers can opt back in with `recordInIframes: true`.
+    if (!(config.recordInIframes ?? false) && isInsideIframe()) {
+      this.stopped = true;
+      if (this.debug) {
+        console.log(
+          "[hercules/session-replay] skipped: page is inside an iframe. " +
+            "Pass recordInIframes: true to record anyway.",
+        );
+      }
+      return;
+    }
+
+    // Skip headless / automation runtimes (Puppeteer, Playwright,
+    // Lighthouse, the Cursor IDE preview Chromium, generic bots). These
+    // sessions are tooling, not real users, and they often run for hours
+    // generating endless animation chunks.
+    if (!(config.recordInHeadless ?? false) && isHeadlessBrowser()) {
+      this.stopped = true;
+      if (this.debug) {
+        console.log(
+          "[hercules/session-replay] skipped: headless or automated browser detected. " +
+            "Pass recordInHeadless: true to record anyway.",
+        );
+      }
+      return;
+    }
+
+    // If the page is opened in a background tab we still attach listeners,
+    // but we don't start rrweb until it becomes visible. This avoids
+    // recording (and uploading) snapshots for tabs the user never sees.
+    if (document.visibilityState === "visible") {
+      this.startRrweb();
+      this.startFlushTimer();
+    } else {
+      this.paused = true;
+    }
+
+    document.addEventListener("visibilitychange", this.handleVisibilityChange);
+    window.addEventListener("pagehide", this.handlePageHide);
+
+    if (this.debug) {
+      console.log("[hercules/session-replay] recording started", {
+        sessionId: this.sessionId,
+        paused: this.paused,
+      });
+    }
+  }
+
+  private startRrweb(): void {
+    if (this.stopFn) return;
+    const stop = record({
+      emit: (event) => {
+        this.buffer.push(event);
+      },
+      checkoutEveryNms: this.checkoutEveryNms,
+      maskAllInputs: this.maskAllInputs,
+    });
+    this.stopFn = stop ?? undefined;
+  }
+
+  private stopRrweb(): void {
+    this.stopFn?.();
+    this.stopFn = undefined;
+  }
+
+  private startFlushTimer(): void {
+    if (this.flushTimer) return;
+    this.flushTimer = setInterval(() => {
+      void this.flush();
+    }, this.flushIntervalMs);
+  }
+
+  private stopFlushTimer(): void {
+    if (this.flushTimer) {
+      clearInterval(this.flushTimer);
+      this.flushTimer = undefined;
+    }
+  }
+
+  private handleVisibilityChange = (): void => {
+    if (this.stopped) return;
+    if (document.visibilityState === "hidden") {
+      this.pauseRecording();
+    } else if (document.visibilityState === "visible") {
+      this.resumeRecording();
+    }
+  };
+
+  private handlePageHide = (): void => {
+    void this.flush({ isUnload: true });
+  };
+
+  /**
+   * Stop emitting rrweb events and tear down the flush timer while the
+   * tab is in the background. We flush via the unload-safe path because
+   * `visibilitychange → hidden` is also what browsers fire when the user
+   * is closing the tab — if we used a plain fetch here it would be killed
+   * mid-flight by the unload that follows, dropping the last chunk.
+   * `flush({ isUnload: true })` uses sendBeacon (or a best-effort plain
+   * fetch for oversized bodies) so the request survives teardown.
+   */
+  private pauseRecording(): void {
+    if (this.paused) return;
+    this.paused = true;
+    void this.flush({ isUnload: true });
+    this.stopFlushTimer();
+    this.stopRrweb();
+    if (this.debug) {
+      console.log("[hercules/session-replay] paused (tab hidden)");
+    }
+  }
+
+  /**
+   * Re-attach the rrweb recorder. rrweb will produce a fresh full snapshot
+   * as the first event of the next chunk so the player can resume from a
+   * clean state.
+   */
+  private resumeRecording(): void {
+    if (!this.paused) return;
+    this.paused = false;
+    this.chunkStartedAt = Date.now();
+    this.startRrweb();
+    this.startFlushTimer();
+    if (this.debug) {
+      console.log("[hercules/session-replay] resumed (tab visible)");
+    }
+  }
+
+  async flush({ isUnload = false }: { isUnload?: boolean } = {}): Promise<void> {
+    if (this.stopped) return;
+    if (this.buffer.length === 0) return;
+
+    const events = this.buffer;
+    this.buffer = [];
+    const startedAt = this.chunkStartedAt;
+    const endedAt = Date.now();
+    this.chunkStartedAt = endedAt;
+    const chunkIndex = this.chunkIndex++;
+
+    const viewport = getViewport();
+    const device = getDeviceInfo();
+
+    const meta: SessionReplayChunkMeta = {
+      user_agent: device.userAgent,
+      viewport_width: viewport.width,
+      viewport_height: viewport.height,
+      url: typeof window !== "undefined" ? window.location.href : null,
+      domain: typeof window !== "undefined" ? window.location.hostname : null,
+      device_type: device.deviceType,
+      user_id: this.userId ?? null,
+    };
+
+    const payload: SessionReplayChunk = {
+      session_id: this.sessionId,
+      chunk_index: chunkIndex,
+      started_at: startedAt,
+      ended_at: endedAt,
+      events,
+      meta,
+    };
+
+    const body = JSON.stringify(payload);
+
+    try {
+      // Both `sendBeacon` and `fetch({ keepalive: true })` cap the request
+      // body at ~64 KB. The first chunk contains a full DOM snapshot which
+      // routinely exceeds that. Strategy:
+      //   - Unload + small body → sendBeacon (queued by the browser, survives
+      //     teardown).
+      //   - Unload + large body → plain fetch (best-effort during the
+      //     browser's unload grace period; we cannot use keepalive because
+      //     it would throw synchronously on oversized bodies).
+      //   - Periodic flush (not unloading) → plain fetch, no size limit.
+      // Leave a little headroom under the 64 KB cap for browser overhead.
+      const KEEPALIVE_MAX_BYTES = 60_000;
+      const fitsInBeacon = body.length <= KEEPALIVE_MAX_BYTES;
+
+      const sentViaBeacon =
+        isUnload &&
+        fitsInBeacon &&
+        typeof navigator !== "undefined" &&
+        typeof navigator.sendBeacon === "function" &&
+        navigator.sendBeacon(this.apiEndpoint, new Blob([body], { type: "application/json" }));
+
+      if (!sentViaBeacon) {
+        await fetch(this.apiEndpoint, {
+          method: "POST",
+          headers: { "Content-Type": "application/json" },
+          body,
+          keepalive: isUnload && fitsInBeacon,
+        });
+      }
+
+      if (this.debug) {
+        console.log("[hercules/session-replay] flushed chunk", {
+          chunkIndex,
+          eventCount: events.length,
+        });
+      }
+    } catch (error) {
+      if (this.debug) {
+        console.error("[hercules/session-replay] flush error", error);
+      }
+      this.buffer.unshift(...events);
+      this.chunkIndex = chunkIndex;
+      this.chunkStartedAt = startedAt;
+    }
+  }
+
+  async stop(): Promise<void> {
+    if (this.stopped) return;
+    this.stopped = true;
+    this.stopFlushTimer();
+    this.stopRrweb();
+    if (typeof document !== "undefined") {
+      document.removeEventListener("visibilitychange", this.handleVisibilityChange);
+    }
+    if (typeof window !== "undefined") {
+      window.removeEventListener("pagehide", this.handlePageHide);
+    }
+    await this.flush();
+  }
+}
+
+let defaultInstance: SessionReplayRecorder | undefined;
+
+function getSessionReplayInstance(config: SessionReplayConfig): SessionReplayRecorder {
+  defaultInstance ??= new SessionReplayRecorder(config);
+  return defaultInstance;
+}
+
+export function initSessionReplay(config: SessionReplayConfig): SessionReplayInstance {
+  const instance = getSessionReplayInstance(config);
+  return {
+    sessionId: instance.sessionId,
+    flush: () => instance.flush(),
+    stop: () => instance.stop(),
+  };
+}

--- a/packages/session-replay/src/schema.ts
+++ b/packages/session-replay/src/schema.ts
@@ -1,0 +1,25 @@
+import * as z from "zod/mini";
+
+export const DeviceTypeEnum = z.enum(["mobile", "tablet", "desktop", "unknown"]);
+export type DeviceType = z.infer<typeof DeviceTypeEnum>;
+
+export const SessionReplayChunkMetaSchema = z.object({
+  user_agent: z.nullish(z.string()),
+  viewport_width: z.nullish(z.number()),
+  viewport_height: z.nullish(z.number()),
+  url: z.nullish(z.string()),
+  domain: z.nullish(z.string()),
+  device_type: z.nullish(DeviceTypeEnum),
+  user_id: z.nullish(z.string()),
+});
+export type SessionReplayChunkMeta = z.infer<typeof SessionReplayChunkMetaSchema>;
+
+export const SessionReplayChunkSchema = z.object({
+  session_id: z.string(),
+  chunk_index: z.number(),
+  started_at: z.number(),
+  ended_at: z.number(),
+  events: z.array(z.unknown()),
+  meta: SessionReplayChunkMetaSchema,
+});
+export type SessionReplayChunk = z.infer<typeof SessionReplayChunkSchema>;

--- a/packages/session-replay/src/types.ts
+++ b/packages/session-replay/src/types.ts
@@ -1,0 +1,51 @@
+import type { DeviceType } from "./schema";
+
+export type SessionReplayConfig = {
+  /** API endpoint to POST chunks to. Defaults to "/_hercules/r" */
+  apiEndpoint?: string;
+  /** Sample rate from 0-100. Decides whether the session records at all. Defaults to 100. */
+  sampleRate?: number;
+  /** Optional end-user identifier to associate the recording with */
+  userId?: string;
+  /** Enable debug logging to the console */
+  debug?: boolean;
+  /** How often (ms) to flush a chunk of buffered events. Defaults to 10_000. */
+  flushIntervalMs?: number;
+  /** rrweb checkout interval — full snapshot interval (ms). Defaults to 30_000. */
+  checkoutEveryNms?: number;
+  /** Mask all input fields (recommended). Defaults to true. */
+  maskAllInputs?: boolean;
+  /**
+   * Record sessions when the page is loaded inside an iframe (e.g. the
+   * Hercules dashboard preview, third-party embeds, OAuth popups).
+   * Defaults to `false` so the dashboard's preview iframe doesn't generate
+   * spurious recordings while you're working on your app.
+   */
+  recordInIframes?: boolean;
+  /**
+   * Record sessions inside headless / automated browsers (Puppeteer,
+   * Playwright, Lighthouse, the Cursor IDE preview Chromium, generic bots
+   * with `navigator.webdriver`, etc.). Defaults to `false` because these
+   * are almost always tooling, not real users.
+   */
+  recordInHeadless?: boolean;
+};
+
+export type SessionReplayInstance = {
+  /** Stable session id used to group chunks */
+  sessionId: string;
+  /** Force-flush any buffered events */
+  flush: () => Promise<void>;
+  /** Stop recording and flush remaining events */
+  stop: () => Promise<void>;
+};
+
+export type ViewportInfo = {
+  width: number;
+  height: number;
+};
+
+export type DeviceInfo = {
+  deviceType: DeviceType;
+  userAgent: string;
+};

--- a/packages/session-replay/src/utils.ts
+++ b/packages/session-replay/src/utils.ts
@@ -1,0 +1,94 @@
+import Bowser from "bowser";
+import { ulid } from "ulid";
+import type { DeviceInfo, ViewportInfo } from "./types";
+import type { DeviceType } from "./schema";
+
+export function generateSessionId(): string {
+  return ulid();
+}
+
+export function getViewport(): ViewportInfo {
+  if (typeof window === "undefined") {
+    return { width: 0, height: 0 };
+  }
+  return {
+    width: window.innerWidth,
+    height: window.innerHeight,
+  };
+}
+
+export function getDeviceInfo(): DeviceInfo {
+  const ua = typeof navigator !== "undefined" ? navigator.userAgent : "";
+  let deviceType: DeviceType = "unknown";
+  try {
+    const parsed = Bowser.parse(ua);
+    const platformType = parsed.platform.type;
+    if (platformType === "mobile") deviceType = "mobile";
+    else if (platformType === "tablet") deviceType = "tablet";
+    else if (platformType === "desktop") deviceType = "desktop";
+  } catch {
+    // best-effort
+  }
+  return { deviceType, userAgent: ua };
+}
+
+const SESSION_STORAGE_KEY = "_hrc_replay_sid";
+
+export function getOrCreatePersistedSessionId(): string {
+  if (typeof sessionStorage === "undefined") {
+    return generateSessionId();
+  }
+  const existing = sessionStorage.getItem(SESSION_STORAGE_KEY);
+  if (existing) return existing;
+  const fresh = generateSessionId();
+  try {
+    sessionStorage.setItem(SESSION_STORAGE_KEY, fresh);
+  } catch {
+    // ignore (Safari private mode etc.)
+  }
+  return fresh;
+}
+
+export function shouldRecord(sampleRate: number | undefined): boolean {
+  // Check sample rate against a random number
+  if (sampleRate == null) return true;
+  if (sampleRate >= 100) return true;
+  if (sampleRate <= 0) return false;
+  return Math.random() * 100 < sampleRate;
+}
+
+/**
+ * Detects whether the current document is loaded inside an iframe. Used to
+ * skip recording in the dashboard preview pane (and other embeds) by
+ * default. We compare against `window.top` rather than `window.parent` so
+ * that nested iframes are also caught. If the comparison throws (some
+ * sandboxed contexts), assume we are framed.
+ */
+export function isInsideIframe(): boolean {
+  if (typeof window === "undefined") return false;
+  try {
+    return window.self !== window.top;
+  } catch {
+    return true;
+  }
+}
+
+// User agent substrings that identify automation runtimes (headless
+// Chromium, Cursor IDE preview, Puppeteer, Playwright, Lighthouse, link
+// checkers, generic crawlers). Match is case-insensitive.
+const HEADLESS_UA_PATTERN =
+  /HeadlessChrome|Headless|Puppeteer|Playwright|Lighthouse|PhantomJS|Selenium|WebDriver|Cypress|Crawler|bot\b|spider|scrapy|curl\/|wget\//i;
+
+/**
+ * Detects automated / headless browsers so we don't fill storage with
+ * recordings from preview tooling, smoke tests, link previewers and
+ * crawlers. Combines the standard `navigator.webdriver` flag with a
+ * UA pattern (catches headless Chromium that doesn't always set the
+ * flag, e.g. Cursor IDE's bundled browser).
+ */
+export function isHeadlessBrowser(): boolean {
+  if (typeof navigator === "undefined") return false;
+  if (navigator.webdriver) return true;
+  if (HEADLESS_UA_PATTERN.test(navigator.userAgent ?? "")) return true;
+  return false;
+}

--- a/packages/session-replay/tsconfig.json
+++ b/packages/session-replay/tsconfig.json
@@ -1,0 +1,34 @@
+{
+  "compilerOptions": {
+    "target": "ES2022",
+    "lib": ["ES2022", "DOM"],
+    "module": "ESNext",
+    "moduleResolution": "bundler",
+
+    "declaration": true,
+    "declarationMap": true,
+    "sourceMap": true,
+    "outDir": "dist",
+    "removeComments": true,
+    "importHelpers": true,
+
+    "isolatedModules": true,
+    "allowSyntheticDefaultImports": true,
+    "esModuleInterop": true,
+    "forceConsistentCasingInFileNames": true,
+    "verbatimModuleSyntax": true,
+
+    "strict": true,
+    "noUnusedLocals": true,
+    "noUnusedParameters": true,
+    "exactOptionalPropertyTypes": true,
+    "noImplicitReturns": true,
+    "noFallthroughCasesInSwitch": true,
+    "noUncheckedIndexedAccess": true,
+    "noImplicitOverride": true,
+
+    "skipLibCheck": true
+  },
+  "include": ["src/**/*"],
+  "exclude": ["node_modules", "dist", "**/*.test.*", "**/*.spec.*"]
+}

--- a/packages/session-replay/tsdown.config.ts
+++ b/packages/session-replay/tsdown.config.ts
@@ -1,0 +1,25 @@
+import { defineConfig } from "tsdown";
+
+export default defineConfig((options) => [
+  {
+    ...options,
+    outDir: "dist/es",
+    entry: ["src/index.ts", "src/utils.ts", "src/types.ts", "src/schema.ts"],
+    dts: true,
+    sourcemap: true,
+    ignoreWatch: [".turbo"],
+  },
+  // ESM build for <script type="module"> tags
+  {
+    ...options,
+    outDir: "dist/browser",
+    target: "es2022",
+    platform: "browser",
+    entry: ["src/auto-init.ts"],
+    dts: false,
+    sourcemap: false,
+    minify: true,
+    ignoreWatch: [".turbo"],
+    noExternal: ["ulid", "bowser", "rrweb"],
+  },
+]);

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -129,6 +129,28 @@ importers:
         specifier: ^4.0.18
         version: 4.0.18(@types/node@24.10.15)(jsdom@28.1.0)
 
+  packages/session-replay:
+    dependencies:
+      bowser:
+        specifier: ^2.14.1
+        version: 2.14.1
+      rrweb:
+        specifier: ^2.0.0-alpha.4
+        version: 2.0.0-alpha.4
+      ulid:
+        specifier: ^3.0.2
+        version: 3.0.2
+      zod:
+        specifier: ^4.3.6
+        version: 4.3.6
+    devDependencies:
+      tsdown:
+        specifier: ^0.18.4
+        version: 0.18.4(typescript@5.9.3)
+      typescript:
+        specifier: ^5.9.3
+        version: 5.9.3
+
   packages/vite:
     dependencies:
       '@babel/generator':
@@ -972,6 +994,9 @@ packages:
     cpu: [x64]
     os: [win32]
 
+  '@rrweb/types@2.0.0-alpha.20':
+    resolution: {integrity: sha512-RbnDgKxA/odwB1R4gF7eUUj+rdSrq6ROQJsnMw7MIsGzlbSYvJeZN8YY4XqU0G6sKJvXI6bSzk7w/G94jNwzhw==}
+
   '@standard-schema/spec@1.1.0':
     resolution: {integrity: sha512-l2aFy5jALhniG5HgqrD6jXLi/rUWrKvqN/qJx6yoJsgKhblVd+iqqU4RCXavm/jPityDo5TCvKMnpjKnOriy0w==}
 
@@ -1018,6 +1043,9 @@ packages:
 
   '@types/chai@5.2.3':
     resolution: {integrity: sha512-Mw558oeA9fFbv65/y4mHtXDs9bPnFMZAL/jxdPFUpOHHIXX91mcgEHbS5Lahr+pwZFR8A7GQleRWeI6cGFC2UA==}
+
+  '@types/css-font-loading-module@0.0.7':
+    resolution: {integrity: sha512-nl09VhutdjINdWyXxHWN/w9zlNCfr60JUqJbd24YXUuCwgeL0TpFSdElCwb6cxfB6ybE19Gjj4g0jsgkXxKv1Q==}
 
   '@types/deep-eql@4.0.2':
     resolution: {integrity: sha512-c9h9dVVMigMPc4bwTvC5dxqtqJZwQPePsWjPlpSOnojbor6pGqdk541lfA7AqFQr5pB1BRdq0juY9db81BwyFw==}
@@ -1133,6 +1161,9 @@ packages:
   '@vitest/utils@4.0.18':
     resolution: {integrity: sha512-msMRKLMVLWygpK3u2Hybgi4MNjcYJvwTb0Ru09+fOyCXIgT5raYP041DRRdiJiI3k/2U6SEbAETB3YtBrUkCFA==}
 
+  '@xstate/fsm@1.6.5':
+    resolution: {integrity: sha512-b5o1I6aLNeYlU/3CPlj/Z91ybk1gUsKT+5NAJI+2W4UjvS5KLG28K9v5UvNoFVjHV8PajVZ00RH3vnjyQO7ZAw==}
+
   acorn-jsx@5.3.2:
     resolution: {integrity: sha512-rq9s+JNhf0IChjtDXxllJ7g41oZk5SlXtp0LHwyA5cejwn7vKmKp4pPri6YEePv2PU65sAsegbXtIinmDFDXgQ==}
     peerDependencies:
@@ -1190,6 +1221,10 @@ packages:
   balanced-match@4.0.4:
     resolution: {integrity: sha512-BLrgEcRTwX2o6gGxGOCNyMvGSp35YofuYzw9h1IMTRmKqttAZZVU67bdb9Pr2vUHA8+j3i2tJfjO6C6+4myGTA==}
     engines: {node: 18 || 20 || >=22}
+
+  base64-arraybuffer@1.0.2:
+    resolution: {integrity: sha512-I3yl4r9QB5ZRY3XuJVEPfc2XhZO6YweFPI+UovAzn+8/hb3oJ6lnysaFcjVpkCPfVWFUDvoZ8kmVDP7WyRtYtQ==}
+    engines: {node: '>= 0.6.0'}
 
   bidi-js@1.0.3:
     resolution: {integrity: sha512-RKshQI1R3YQ+n9YJz2QQ147P66ELpa1FQEg20Dk8oW9t2KgLbpDLLp9aGZ7y8WHSshDknG0bknqGw5/tyCs5tw==}
@@ -1404,6 +1439,9 @@ packages:
       picomatch:
         optional: true
 
+  fflate@0.4.8:
+    resolution: {integrity: sha512-FJqqoDBR00Mdj9ppamLa/Y7vxm+PRmNWA67N846RvsoYVMKB4q3y/de5PA7gUmRMYK/8CMz2GDZQmCRN1wBcWA==}
+
   file-entry-cache@8.0.0:
     resolution: {integrity: sha512-XXTUwCvisa5oacNGRP9SfNtYBNAMi+RPwBFmblZEF7N7swHYQS6/Zfk7SRwx4D5j3CH211YNRco1DEMNVfZCnQ==}
     engines: {node: '>=16.0.0'}
@@ -1565,6 +1603,9 @@ packages:
   minimatch@3.1.5:
     resolution: {integrity: sha512-VgjWUsnnT6n+NUk6eZq77zeFdpW2LWDzP6zFGrCbHXiYNul5Dzqk2HHQ5uFH2DNW5Xbp8+jVzaeNt94ssEEl4w==}
 
+  mitt@3.0.1:
+    resolution: {integrity: sha512-vKivATfr97l2/QBCYAkXYDbrIWPM2IIKEl7YPhjCvKlG3kE2gm+uBo6nEXK3M5/Ffh/FLpKExzOQ3JJoJGFKBw==}
+
   ms@2.1.3:
     resolution: {integrity: sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA==}
 
@@ -1711,6 +1752,15 @@ packages:
     resolution: {integrity: sha512-2oMpl67a3zCH9H79LeMcbDhXW/UmWG/y2zuqnF2jQq5uq9TbM9TVyXvA4+t+ne2IIkBdrLpAaRQAvo7YI/Yyeg==}
     engines: {node: '>=18.0.0', npm: '>=8.0.0'}
     hasBin: true
+
+  rrdom@0.1.7:
+    resolution: {integrity: sha512-ZLd8f14z9pUy2Hk9y636cNv5Y2BMnNEY99wxzW9tD2BLDfe1xFxtLjB4q/xCBYo6HRe0wofzKzjm4JojmpBfFw==}
+
+  rrweb-snapshot@2.0.0-alpha.4:
+    resolution: {integrity: sha512-KQ2OtPpXO5jLYqg1OnXS/Hf+EzqnZyP5A+XPqBCjYpj3XIje/Od4gdUwjbFo3cVuWq5Cw5Y1d3/xwgIS7/XpQQ==}
+
+  rrweb@2.0.0-alpha.4:
+    resolution: {integrity: sha512-wEHUILbxDPcNwkM3m4qgPgXAiBJyqCbbOHyVoNEVBJzHszWEFYyTbrZqUdeb1EfmTRC2PsumCIkVcomJ/xcOzA==}
 
   saxes@6.0.0:
     resolution: {integrity: sha512-xAg7SOnEhrm5zI3puOOKyy1OMcMlIJZYNJY7xLBwSze0UjhPLnWfj2GF2EpT0jmzaJKIWKHLsaSSajf35bcYnA==}
@@ -2551,6 +2601,8 @@ snapshots:
   '@rollup/rollup-win32-x64-msvc@4.59.0':
     optional: true
 
+  '@rrweb/types@2.0.0-alpha.20': {}
+
   '@standard-schema/spec@1.1.0': {}
 
   '@testing-library/dom@10.4.1':
@@ -2615,6 +2667,8 @@ snapshots:
     dependencies:
       '@types/deep-eql': 4.0.2
       assertion-error: 2.0.1
+
+  '@types/css-font-loading-module@0.0.7': {}
 
   '@types/deep-eql@4.0.2': {}
 
@@ -2778,6 +2832,8 @@ snapshots:
       '@vitest/pretty-format': 4.0.18
       tinyrainbow: 3.0.3
 
+  '@xstate/fsm@1.6.5': {}
+
   acorn-jsx@5.3.2(acorn@8.16.0):
     dependencies:
       acorn: 8.16.0
@@ -2821,6 +2877,8 @@ snapshots:
   balanced-match@1.0.2: {}
 
   balanced-match@4.0.4: {}
+
+  base64-arraybuffer@1.0.2: {}
 
   bidi-js@1.0.3:
     dependencies:
@@ -3066,6 +3124,8 @@ snapshots:
     optionalDependencies:
       picomatch: 4.0.3
 
+  fflate@0.4.8: {}
+
   file-entry-cache@8.0.0:
     dependencies:
       flat-cache: 4.0.1
@@ -3221,6 +3281,8 @@ snapshots:
   minimatch@3.1.5:
     dependencies:
       brace-expansion: 1.1.12
+
+  mitt@3.0.1: {}
 
   ms@2.1.3: {}
 
@@ -3398,6 +3460,23 @@ snapshots:
       '@rollup/rollup-win32-x64-gnu': 4.59.0
       '@rollup/rollup-win32-x64-msvc': 4.59.0
       fsevents: 2.3.3
+
+  rrdom@0.1.7:
+    dependencies:
+      rrweb-snapshot: 2.0.0-alpha.4
+
+  rrweb-snapshot@2.0.0-alpha.4: {}
+
+  rrweb@2.0.0-alpha.4:
+    dependencies:
+      '@rrweb/types': 2.0.0-alpha.20
+      '@types/css-font-loading-module': 0.0.7
+      '@xstate/fsm': 1.6.5
+      base64-arraybuffer: 1.0.2
+      fflate: 0.4.8
+      mitt: 3.0.1
+      rrdom: 0.1.7
+      rrweb-snapshot: 2.0.0-alpha.4
 
   saxes@6.0.0:
     dependencies:


### PR DESCRIPTION
# feat: `@usehercules/session-replay` package
New rrweb-based session replay recorder for Hercules apps. Records DOM/UI
events in the browser and POSTs gzippable JSON chunks to a configurable
ingest endpoint (default `/_hercules/r`). Companion server-side ingest +
playback lives in `withzeusai/hercules.app#feat/session-replay`.
Branch: `feat/session-replay` · Commit: `a9058ff`
## What ships
```
packages/session-replay/
├── src/
│   ├── index.ts        SessionReplayRecorder + initSessionReplay()
│   ├── auto-init.ts    parses URL params, starts recorder on import
│   ├── schema.ts       SessionReplayChunk(Meta) zod schemas
│   ├── types.ts        SessionReplayConfig / Instance
│   └── utils.ts        viewport, device, headless + iframe detection
├── scripts/generate-script-export.mjs
├── tsdown.config.ts
└── package.json        (rrweb, bowser, ulid, zod)
```
Exports: `.` (programmatic), `./schema`, `./types`, `./utils`, `./script`
(pre-bundled browser auto-init for `<script type="module">` tags).
## How it works
```mermaid
sequenceDiagram
    autonumber
    participant Page as Host page
    participant SR as SessionReplayRecorder
    participant rrweb
    participant Ingest as apiEndpoint<br/>(default /_hercules/r)
    Page->>SR: import "@usehercules/session-replay/script"<br/>?apiEndpoint=…&sampleRate=…&debug=…
    SR->>SR: shouldRecord(sampleRate)?<br/>iframe / headless gate
    SR->>rrweb: record({ maskAllInputs, checkoutEveryNms })
    loop every flushIntervalMs (10s)
      rrweb-->>SR: events
      SR->>Ingest: POST { session_id, chunk_index,<br/>started_at, ended_at, events, meta }
    end
    Note over Page,SR: visibilitychange→hidden:<br/>flush via sendBeacon, stop rrweb
    Note over Page,SR: pagehide: final flush via sendBeacon<br/>(plain fetch fallback for >60KB)
```
`session_id` is a ULID persisted in `sessionStorage` so it's stable across
chunks for the same tab.
## Usage
Programmatic:
```ts
import { initSessionReplay } from "@usehercules/session-replay";
initSessionReplay({
  apiEndpoint: "/_hercules/r",
  userId: currentUser?.id,
  sampleRate: 100,
});
```
Script tag (auto-init from URL params):
```html
<script
  type="module"
  src="https://cdn/.../session-replay/script?apiEndpoint=/_hercules/r&sampleRate=100"
></script>
```
## Defaults / safety
- `maskAllInputs: true` — input values never leave the browser.
- Skips recording inside iframes (`recordInIframes: false`) so the Hercules
  dashboard preview pane doesn't generate sessions.
- Skips headless / automation runtimes (Puppeteer, Playwright, Lighthouse,
  Cursor IDE preview, generic `webdriver` bots) via UA + `navigator.webdriver`.
- Pauses rrweb on `visibilitychange → hidden` and resumes on visible (rrweb
  emits a fresh full snapshot on resume).
- 10 s flush interval, 30 s rrweb checkout interval.
- 60 KB ceiling on `sendBeacon`/`keepalive` payloads with a plain-fetch
  fallback during the unload grace period for the (typically large) first
  chunk.
## Test plan
- [x] `pnpm build` produces ESM + browser bundles in `dist/`.
- [x] Local: import into a sample app, observe POSTs to `apiEndpoint` every
      ~10 s and a final flush on tab close.
- [x] Verify the recorder is skipped in: dashboard preview iframe,
      Playwright run, Cursor preview Chromium.
- [x] Inputs are masked in the recorded events stream.
- [x] `session_id` persists across navigations within the same tab and
      resets in a new tab.