### PR TITLE
feat: add useAuth hook with smart signout logic

### DIFF
--- a/packages/auth/src/react/HerculesAuthProvider.tsx
+++ b/packages/auth/src/react/HerculesAuthProvider.tsx
@@ -10,6 +10,7 @@ import {
   WebStorageStateStore,
   type UserManagerSettings,
 } from "oidc-client-ts";
+import { createContext, useContext } from "react";
 
 export type HerculesAuthProviderProps = Omit<
   AuthProviderUserManagerProps,
@@ -32,6 +33,21 @@ const DEFAULT_AUTH_CONFIG: Partial<HerculesAuthProviderProps> = {
   onSignoutCallback,
   onSigninCallback,
 };
+
+interface HerculesAuthProviderContext {
+  userManager: UserManager;
+}
+
+const HerculesAuthProviderContext =
+  createContext<HerculesAuthProviderContext | null>(null);
+
+export function useHerculesAuthProvider() {
+  const context = useContext(HerculesAuthProviderContext);
+  if (!context) {
+    throw new Error("HerculesAuthProviderContext not found");
+  }
+  return context;
+}
 
 /**
  * A wrapper React component which provides a {@link ReactAuthProvider}
@@ -69,12 +85,14 @@ export function HerculesAuthProvider({
   );
 
   return (
-    <ReactAuthProvider
-      userManager={userManager}
-      {...DEFAULT_AUTH_CONFIG}
-      {...props}
-    >
-      {children}
-    </ReactAuthProvider>
+    <HerculesAuthProviderContext.Provider value={{ userManager }}>
+      <ReactAuthProvider
+        userManager={userManager}
+        {...DEFAULT_AUTH_CONFIG}
+        {...props}
+      >
+        {children}
+      </ReactAuthProvider>
+    </HerculesAuthProviderContext.Provider>
   );
 }

--- a/packages/auth/src/react/index.ts
+++ b/packages/auth/src/react/index.ts
@@ -1,10 +1,7 @@
 export * from "./auth-callback-hook";
 export * from "./HerculesAuthProvider";
 export * from "./use-user";
+export * from "./use-auth";
 
 // rexports of react-oidc-context
-export {
-  type AuthContextProps,
-  hasAuthParams,
-  useAuth,
-} from "react-oidc-context";
+export { hasAuthParams } from "react-oidc-context";

--- a/packages/auth/src/react/use-auth.test.tsx
+++ b/packages/auth/src/react/use-auth.test.tsx
@@ -1,0 +1,125 @@
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import { renderHook, act, configure } from "@testing-library/react";
+import { useAuth } from "./use-auth.js";
+
+configure({ reactStrictMode: true });
+
+// ---- Mocks ----
+
+const mockSignoutRedirect = vi.fn();
+const mockRemoveUser = vi.fn();
+const mockGetEndSessionEndpoint = vi.fn();
+
+const mockUserManager = {
+  metadataService: {
+    getEndSessionEndpoint: mockGetEndSessionEndpoint,
+  },
+};
+
+let mockAuthState: Record<string, unknown> = {};
+
+vi.mock("react-oidc-context", () => ({
+  useAuth: () => mockAuthState,
+}));
+
+vi.mock("./HerculesAuthProvider", () => ({
+  useHerculesAuthProvider: () => ({ userManager: mockUserManager }),
+}));
+
+// ---- Helpers ----
+
+function setAuthState(overrides: Record<string, unknown>) {
+  mockAuthState = {
+    isLoading: false,
+    isAuthenticated: true,
+    signoutRedirect: mockSignoutRedirect,
+    removeUser: mockRemoveUser,
+    ...overrides,
+  };
+}
+
+// ---- Tests ----
+
+beforeEach(() => {
+  setAuthState({});
+  mockSignoutRedirect.mockReset();
+  mockRemoveUser.mockReset();
+  mockGetEndSessionEndpoint.mockReset();
+});
+
+describe("useAuth", () => {
+  it("returns the underlying auth state with a signout method", () => {
+    const { result } = renderHook(() => useAuth());
+
+    expect(result.current.isAuthenticated).toBe(true);
+    expect(result.current.isLoading).toBe(false);
+    expect(typeof result.current.signout).toBe("function");
+  });
+
+  it("spreads all properties from the oidc auth context", () => {
+    setAuthState({ isAuthenticated: false, isLoading: true });
+
+    const { result } = renderHook(() => useAuth());
+
+    expect(result.current.isAuthenticated).toBe(false);
+    expect(result.current.isLoading).toBe(true);
+  });
+
+  describe("signout", () => {
+    it("calls signoutRedirect when end session endpoint exists", async () => {
+      mockGetEndSessionEndpoint.mockResolvedValue(
+        "https://auth.example.com/logout",
+      );
+      mockSignoutRedirect.mockResolvedValue(undefined);
+
+      const { result } = renderHook(() => useAuth());
+
+      await act(async () => {
+        await result.current.signout();
+      });
+
+      expect(mockGetEndSessionEndpoint).toHaveBeenCalled();
+      expect(mockSignoutRedirect).toHaveBeenCalledOnce();
+      expect(mockRemoveUser).not.toHaveBeenCalled();
+    });
+
+    it("calls removeUser when end session endpoint is null", async () => {
+      mockGetEndSessionEndpoint.mockResolvedValue(null);
+
+      const { result } = renderHook(() => useAuth());
+
+      await act(async () => {
+        await result.current.signout();
+      });
+
+      expect(mockGetEndSessionEndpoint).toHaveBeenCalled();
+      expect(mockSignoutRedirect).not.toHaveBeenCalled();
+      expect(mockRemoveUser).toHaveBeenCalledOnce();
+    });
+
+    it("calls removeUser when end session endpoint is undefined", async () => {
+      mockGetEndSessionEndpoint.mockResolvedValue(undefined);
+
+      const { result } = renderHook(() => useAuth());
+
+      await act(async () => {
+        await result.current.signout();
+      });
+
+      expect(mockSignoutRedirect).not.toHaveBeenCalled();
+      expect(mockRemoveUser).toHaveBeenCalledOnce();
+    });
+  });
+
+  describe("memoization", () => {
+    it("returns a stable signout reference across rerenders with same deps", () => {
+      const { result, rerender } = renderHook(() => useAuth());
+
+      const firstSignout = result.current.signout;
+      rerender();
+      const secondSignout = result.current.signout;
+
+      expect(firstSignout).toBe(secondSignout);
+    });
+  });
+});

--- a/packages/auth/src/react/use-auth.ts
+++ b/packages/auth/src/react/use-auth.ts
@@ -1,14 +1,15 @@
 import {
   useAuth as useOidcAuth,
-  type AuthContextProps,
+  type AuthContextProps as OidcAuthContextProps,
 } from "react-oidc-context";
 import { useHerculesAuthProvider } from "./HerculesAuthProvider";
 import { useCallback, useMemo } from "react";
 
-interface UseHerculesAuthResult extends AuthContextProps {
+export interface AuthContextProps extends OidcAuthContextProps {
   signout: () => Promise<void>;
 }
-export function useAuth(): UseHerculesAuthResult {
+
+export function useAuth(): AuthContextProps {
   const { userManager } = useHerculesAuthProvider();
   const auth = useOidcAuth();
 
@@ -18,7 +19,7 @@ export function useAuth(): UseHerculesAuthResult {
     if (endpoint != null) {
       await signoutRedirect();
     } else {
-      removeUser();
+      await removeUser();
     }
   }, [userManager, signoutRedirect, removeUser]);
 
@@ -26,6 +27,6 @@ export function useAuth(): UseHerculesAuthResult {
     return {
       ...auth,
       signout,
-    } satisfies UseHerculesAuthResult;
+    } satisfies AuthContextProps;
   }, [auth, signout]);
 }

--- a/packages/auth/src/react/use-auth.ts
+++ b/packages/auth/src/react/use-auth.ts
@@ -1,0 +1,31 @@
+import {
+  useAuth as useOidcAuth,
+  type AuthContextProps,
+} from "react-oidc-context";
+import { useHerculesAuthProvider } from "./HerculesAuthProvider";
+import { useCallback, useMemo } from "react";
+
+interface UseHerculesAuthResult extends AuthContextProps {
+  signout: () => Promise<void>;
+}
+export function useAuth(): UseHerculesAuthResult {
+  const { userManager } = useHerculesAuthProvider();
+  const auth = useOidcAuth();
+
+  const { signoutRedirect, removeUser } = auth;
+  const signout = useCallback(async () => {
+    const endpoint = await userManager.metadataService.getEndSessionEndpoint();
+    if (endpoint != null) {
+      await signoutRedirect();
+    } else {
+      removeUser();
+    }
+  }, [userManager, signoutRedirect, removeUser]);
+
+  return useMemo(() => {
+    return {
+      ...auth,
+      signout,
+    } satisfies UseHerculesAuthResult;
+  }, [auth, signout]);
+}


### PR DESCRIPTION
## Summary
- Adds a `useAuth` hook that wraps `react-oidc-context` with a `signout` method that checks for an OIDC end session endpoint before deciding between redirect signout and local user removal
- Exposes `UserManager` via a new `HerculesAuthProviderContext` so hooks can access it directly
- Updates `useUser` to import from the new local `useAuth` hook

## Test plan
- [x] Added unit tests for `useAuth` hook covering signout redirect, removeUser fallback, and memoization stability
- [ ] Verify existing auth flows still work end-to-end in a browser

🤖 Generated with [Claude Code](https://claude.com/claude-code)