### PR TITLE
feat: add signin method to useAuth hook

### DIFF
--- a/.changeset/add-signin-method.md
+++ b/.changeset/add-signin-method.md
@@ -1,0 +1,5 @@
+---
+"@usehercules/auth": patch
+---
+
+Add `signin` method to `useAuth` hook that wraps `signinRedirect` in a stable callback

--- a/packages/auth/src/react/use-auth.test.tsx
+++ b/packages/auth/src/react/use-auth.test.tsx
@@ -7,6 +7,7 @@ configure({ reactStrictMode: true });
 // ---- Mocks ----
 
 const mockSignoutRedirect = vi.fn();
+const mockSigninRedirect = vi.fn();
 const mockRemoveUser = vi.fn();
 const mockGetEndSessionEndpoint = vi.fn();
 
@@ -33,6 +34,7 @@ function setAuthState(overrides: Record<string, unknown>) {
     isLoading: false,
     isAuthenticated: true,
     signoutRedirect: mockSignoutRedirect,
+    signinRedirect: mockSigninRedirect,
     removeUser: mockRemoveUser,
     ...overrides,
   };
@@ -43,6 +45,7 @@ function setAuthState(overrides: Record<string, unknown>) {
 beforeEach(() => {
   setAuthState({});
   mockSignoutRedirect.mockReset();
+  mockSigninRedirect.mockReset();
   mockRemoveUser.mockReset();
   mockGetEndSessionEndpoint.mockReset();
 });
@@ -54,6 +57,7 @@ describe("useAuth", () => {
     expect(result.current.isAuthenticated).toBe(true);
     expect(result.current.isLoading).toBe(false);
     expect(typeof result.current.signout).toBe("function");
+    expect(typeof result.current.signin).toBe("function");
   });
 
   it("spreads all properties from the oidc auth context", () => {
@@ -111,6 +115,20 @@ describe("useAuth", () => {
     });
   });
 
+  describe("signin", () => {
+    it("calls signinRedirect", async () => {
+      mockSigninRedirect.mockResolvedValue(undefined);
+
+      const { result } = renderHook(() => useAuth());
+
+      await act(async () => {
+        await result.current.signin();
+      });
+
+      expect(mockSigninRedirect).toHaveBeenCalledOnce();
+    });
+  });
+
   describe("memoization", () => {
     it("returns a stable signout reference across rerenders with same deps", () => {
       const { result, rerender } = renderHook(() => useAuth());
@@ -120,6 +138,16 @@ describe("useAuth", () => {
       const secondSignout = result.current.signout;
 
       expect(firstSignout).toBe(secondSignout);
+    });
+
+    it("returns a stable signin reference across rerenders with same deps", () => {
+      const { result, rerender } = renderHook(() => useAuth());
+
+      const firstSignin = result.current.signin;
+      rerender();
+      const secondSignin = result.current.signin;
+
+      expect(firstSignin).toBe(secondSignin);
     });
   });
 });

--- a/packages/auth/src/react/use-auth.ts
+++ b/packages/auth/src/react/use-auth.ts
@@ -7,13 +7,14 @@ import { useCallback, useMemo } from "react";
 
 export interface AuthContextProps extends OidcAuthContextProps {
   signout: () => Promise<void>;
+  signin: () => Promise<void>;
 }
 
 export function useAuth(): AuthContextProps {
   const { userManager } = useHerculesAuthProvider();
   const auth = useOidcAuth();
 
-  const { signoutRedirect, removeUser } = auth;
+  const { signoutRedirect, removeUser, signinRedirect } = auth;
   const signout = useCallback(async () => {
     const endpoint = await userManager.metadataService.getEndSessionEndpoint();
     if (endpoint != null) {
@@ -23,10 +24,15 @@ export function useAuth(): AuthContextProps {
     }
   }, [userManager, signoutRedirect, removeUser]);
 
+  const signin = useCallback(async () => {
+    await signinRedirect();
+  }, [signinRedirect]);
+
   return useMemo(() => {
     return {
       ...auth,
       signout,
+      signin,
     } satisfies AuthContextProps;
-  }, [auth, signout]);
+  }, [auth, signout, signin]);
 }


### PR DESCRIPTION
## Summary
- Add `signin` method to `useAuth` hook that wraps `signinRedirect` in a stable `useCallback`
- Extend `AuthContextProps` interface with `signin: () => Promise<void>`
- Add tests for `signin` invocation and memoization stability

## Test plan
- [x] Existing tests pass (19/19)
- [x] New test: `signin` calls `signinRedirect`
- [x] New test: stable `signin` reference across rerenders

🤖 Generated with [Claude Code](https://claude.com/claude-code)