### PR TITLE
fix(auth): re-enable Convex forced token refresh

### DIFF
--- a/.changeset/fix-convex-token-refresh.md
+++ b/.changeset/fix-convex-token-refresh.md
@@ -1,0 +1,9 @@
+---
+"@usehercules/auth": patch
+---
+
+Re-enable forced token refresh in `ConvexProviderWithHerculesAuth` so Convex
+can recover after a 401 instead of getting the same expired id token back.
+Concurrent refresh requests share a single in-flight `signinSilent` call to
+avoid the React 19 strict-mode duplicate-refresh race that motivated the
+original disable.

--- a/packages/auth/src/convex-react/ConvexProviderWithHercules.test.tsx
+++ b/packages/auth/src/convex-react/ConvexProviderWithHercules.test.tsx
@@ -1,0 +1,196 @@
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import type { ReactNode } from "react";
+import { renderHook, act, configure } from "@testing-library/react";
+import { ConvexProviderWithHerculesAuth } from "./ConvexProviderWithHercules.js";
+
+configure({ reactStrictMode: true });
+
+const mockSigninSilent = vi.fn();
+
+let mockAuthState: Record<string, unknown> = {};
+
+vi.mock("react-oidc-context", () => ({
+  useAuth: () => mockAuthState,
+}));
+
+type CapturedUseAuth = () => {
+  isLoading: boolean;
+  isAuthenticated: boolean;
+  fetchAccessToken: (args: {
+    forceRefreshToken: boolean;
+  }) => Promise<string | null>;
+};
+
+let capturedUseAuth: CapturedUseAuth | null = null;
+
+vi.mock("convex/react", () => ({
+  ConvexProviderWithAuth: ({
+    children,
+    useAuth,
+  }: {
+    children: ReactNode;
+    useAuth: CapturedUseAuth;
+  }) => {
+    capturedUseAuth = useAuth;
+    return children;
+  },
+}));
+
+function setAuthState(overrides: Record<string, unknown>) {
+  mockAuthState = {
+    isLoading: false,
+    isAuthenticated: true,
+    user: { id_token: "cached-token" },
+    signinSilent: mockSigninSilent,
+    ...overrides,
+  };
+}
+
+beforeEach(() => {
+  setAuthState({});
+  mockSigninSilent.mockReset();
+  capturedUseAuth = null;
+});
+
+function renderUseAuth() {
+  renderHook(() => null, {
+    wrapper: ({ children }) => (
+      <ConvexProviderWithHerculesAuth client={{} as never}>
+        {children}
+      </ConvexProviderWithHerculesAuth>
+    ),
+  });
+  if (!capturedUseAuth) {
+    throw new Error("useAuth not captured");
+  }
+  const captured = capturedUseAuth;
+  return renderHook(() => captured());
+}
+
+describe("ConvexProviderWithHerculesAuth fetchAccessToken", () => {
+  it("returns the cached id token when forceRefreshToken is false", async () => {
+    const { result } = renderUseAuth();
+
+    const token = await result.current.fetchAccessToken({
+      forceRefreshToken: false,
+    });
+
+    expect(token).toBe("cached-token");
+    expect(mockSigninSilent).not.toHaveBeenCalled();
+  });
+
+  it("calls signinSilent and returns the refreshed token when forceRefreshToken is true", async () => {
+    mockSigninSilent.mockResolvedValue({ id_token: "fresh-token" });
+
+    const { result } = renderUseAuth();
+
+    let token: string | null = null;
+    await act(async () => {
+      token = await result.current.fetchAccessToken({
+        forceRefreshToken: true,
+      });
+    });
+
+    expect(token).toBe("fresh-token");
+    expect(mockSigninSilent).toHaveBeenCalledOnce();
+  });
+
+  it("returns null when signinSilent throws", async () => {
+    mockSigninSilent.mockRejectedValue(new Error("refresh failed"));
+
+    const { result } = renderUseAuth();
+
+    let token: string | null = "unset";
+    await act(async () => {
+      token = await result.current.fetchAccessToken({
+        forceRefreshToken: true,
+      });
+    });
+
+    expect(token).toBeNull();
+    expect(mockSigninSilent).toHaveBeenCalledOnce();
+  });
+
+  it("returns null when signinSilent resolves without a user", async () => {
+    mockSigninSilent.mockResolvedValue(null);
+
+    const { result } = renderUseAuth();
+
+    let token: string | null = "unset";
+    await act(async () => {
+      token = await result.current.fetchAccessToken({
+        forceRefreshToken: true,
+      });
+    });
+
+    expect(token).toBeNull();
+    expect(mockSigninSilent).toHaveBeenCalledOnce();
+  });
+
+  it("dedupes concurrent forceRefreshToken calls into a single signinSilent", async () => {
+    let resolveSilent: ((value: { id_token: string }) => void) | null = null;
+    mockSigninSilent.mockImplementation(
+      () =>
+        new Promise<{ id_token: string }>((resolve) => {
+          resolveSilent = resolve;
+        }),
+    );
+
+    const { result } = renderUseAuth();
+
+    let firstToken: string | null = null;
+    let secondToken: string | null = null;
+    let thirdToken: string | null = null;
+
+    await act(async () => {
+      const first = result.current.fetchAccessToken({
+        forceRefreshToken: true,
+      });
+      const second = result.current.fetchAccessToken({
+        forceRefreshToken: true,
+      });
+      const third = result.current.fetchAccessToken({
+        forceRefreshToken: true,
+      });
+
+      resolveSilent?.({ id_token: "fresh-token" });
+
+      [firstToken, secondToken, thirdToken] = await Promise.all([
+        first,
+        second,
+        third,
+      ]);
+    });
+
+    expect(firstToken).toBe("fresh-token");
+    expect(secondToken).toBe("fresh-token");
+    expect(thirdToken).toBe("fresh-token");
+    expect(mockSigninSilent).toHaveBeenCalledOnce();
+  });
+
+  it("allows a new refresh after the in-flight refresh settles", async () => {
+    mockSigninSilent
+      .mockResolvedValueOnce({ id_token: "first-fresh" })
+      .mockResolvedValueOnce({ id_token: "second-fresh" });
+
+    const { result } = renderUseAuth();
+
+    let firstToken: string | null = null;
+    let secondToken: string | null = null;
+
+    await act(async () => {
+      firstToken = await result.current.fetchAccessToken({
+        forceRefreshToken: true,
+      });
+    });
+    await act(async () => {
+      secondToken = await result.current.fetchAccessToken({
+        forceRefreshToken: true,
+      });
+    });
+
+    expect(firstToken).toBe("first-fresh");
+    expect(secondToken).toBe("second-fresh");
+    expect(mockSigninSilent).toHaveBeenCalledTimes(2);
+  });
+});

--- a/packages/auth/src/convex-react/ConvexProviderWithHercules.tsx
+++ b/packages/auth/src/convex-react/ConvexProviderWithHercules.tsx
@@ -2,7 +2,7 @@
 
 import type { ReactNode } from "react";
 import { ConvexProviderWithAuth, type ConvexReactClient } from "convex/react";
-import { useCallback, useMemo } from "react";
+import { useCallback, useMemo, useRef } from "react";
 import { useAuth } from "react-oidc-context";
 import type { HerculesAuthProvider } from "../react/HerculesAuthProvider";
 
@@ -31,17 +31,29 @@ export function ConvexProviderWithHerculesAuth({
 function useUseAuthFromHercules() {
   const { isAuthenticated, user, isLoading, signinSilent } = useAuth();
   const idToken = user?.id_token;
+
+  const inFlightRefresh = useRef<Promise<string | null> | null>(null);
+
   const fetchAccessToken = useCallback(
-    async ({ forceRefreshToken: _ignore }: { forceRefreshToken: boolean }) => {
-      try {
-        // if (forceRefreshToken) {
-        //   const user = await signinSilent();
-        //   return user?.id_token ?? null;
-        // }
+    async ({ forceRefreshToken }: { forceRefreshToken: boolean }) => {
+      if (!forceRefreshToken) {
         return idToken ?? null;
-      } catch {
-        return null;
       }
+      if (inFlightRefresh.current) {
+        return inFlightRefresh.current;
+      }
+      const refresh = (async () => {
+        try {
+          const refreshed = await signinSilent();
+          return refreshed?.id_token ?? null;
+        } catch {
+          return null;
+        } finally {
+          inFlightRefresh.current = null;
+        }
+      })();
+      inFlightRefresh.current = refresh;
+      return refresh;
     },
     [idToken, signinSilent],
   );


### PR DESCRIPTION
[CUS-180](https://linear.app/hercules-app/issue/CUS-180)

## Problem

`ConvexProviderWithHerculesAuth` wraps `useAuth()` for Convex. Convex calls `fetchAccessToken({ forceRefreshToken: true })` after a 401, expecting a fresh token. Today the wrapper returns the cached (expired) `idToken` regardless, so `getUserIdentity()` stays `null` indefinitely until the customer hard-reloads the page.

## Why it was disabled

Commit `93ef0cf` ("chore(deps): upgrade Convex to 1.29.3 and React to 19", Grant Gurvis, 2025-11-22) commented out the `signinSilent()` branch in the same change that bumped React 18 to 19. The commit body says only "Disable forceRefreshToken logic in ConvexProviderWithHercules" without explaining why.

The most plausible reason, given the simultaneous React 19 bump, is [react-oidc-context#1638](https://github.com/authts/react-oidc-context/issues/1638): under React 19 strict mode the `useState(() => new UserManager(...))` initializer in `HerculesAuthProvider` runs twice, creating two `UserManager` instances and racing two concurrent refresh-token grants. That race can invalidate the freshly minted token. A naive revert reproduces this.

## Fix

Re-enable `signinSilent()` on `forceRefreshToken: true`, but de-dup concurrent calls through a `useRef<Promise>`:

- The first call kicks off `signinSilent()` and stores the promise.
- Any concurrent `forceRefreshToken: true` call (including a strict-mode double-invocation, or Convex retrying multiple subscriptions in parallel) reuses the in-flight promise.
- The ref is cleared in `finally`, so the next genuine refresh window can start a new call.

`HerculesAuthProvider` configures `scope: "openid profile email offline_access"` by default, so `oidc-client-ts` uses the refresh-token grant for `signinSilent()` rather than the hidden iframe. That means no `silent_redirect_uri` is required and we are not dependent on iframe behavior inside the Hercules preview.

## Verification

- `pnpm -C packages/auth test` - 25 tests pass, including 6 new tests covering: cached token return, refresh on force, error/null fallthrough, concurrent dedup (single `signinSilent` for three parallel calls), and a fresh refresh after the previous one settles.
- `pnpm -C packages/auth build` - clean.
- `pnpm turbo run build test` from the repo root - all 8 tasks pass.

How I would verify in a Hercules customer app:

1. Sign in to a customer app that uses `@usehercules/auth/convex-react`.
2. Wait until the OIDC access/id token expires (or shorten its lifetime via the IdP for testing) and trigger a Convex query.
3. Convex should call `fetchAccessToken({ forceRefreshToken: true })`, the wrapper should call `signinSilent`, and `getUserIdentity()` should return the new identity without a page reload.
4. Open multiple Convex subscriptions in parallel and force-expire the token to confirm only one `signinSilent` request hits the IdP (network panel).

## Follow-ups

- I cannot run a real customer app from this repo, so step 1-4 above is the test plan, not test results. Worth a smoke test on a staging customer before publishing.
- If the upstream `react-oidc-context` strict-mode double-init issue (#1638) is fixed, we could drop the `useRef` guard, but it remains a cheap belt-and-braces.