### PR TITLE
fix(auth): honor forceRefreshToken in Convex bridge

### DIFF
--- a/.changeset/fix-convex-force-refresh-token.md
+++ b/.changeset/fix-convex-force-refresh-token.md
@@ -1,0 +1,5 @@
+---
+"@usehercules/auth": patch
+---
+
+Honor `forceRefreshToken` in the Convex auth bridge so Convex can recover when its access token expires. Previously the flag was ignored and the same stale id_token was returned, which caused end users on idle sessions (especially backgrounded PWAs on iOS) to be silently signed out after the access token expired even though the refresh token was still valid. `signinSilent()` is now called when `forceRefreshToken` is true, mirroring the pre-1.0.41 behavior that was accidentally commented out during the React 19 / Convex 1.29 upgrade.

--- a/packages/auth/src/convex-react/ConvexProviderWithHercules.tsx
+++ b/packages/auth/src/convex-react/ConvexProviderWithHercules.tsx
@@ -32,12 +32,12 @@ function useUseAuthFromHercules() {
   const { isAuthenticated, user, isLoading, signinSilent } = useAuth();
   const idToken = user?.id_token;
   const fetchAccessToken = useCallback(
-    async ({ forceRefreshToken: _ignore }: { forceRefreshToken: boolean }) => {
+    async ({ forceRefreshToken }: { forceRefreshToken: boolean }) => {
       try {
-        // if (forceRefreshToken) {
-        //   const user = await signinSilent();
-        //   return user?.id_token ?? null;
-        // }
+        if (forceRefreshToken) {
+          const refreshed = await signinSilent();
+          return refreshed?.id_token ?? null;
+        }
         return idToken ?? null;
       } catch {
         return null;


### PR DESCRIPTION
https://linear.app/hercules-app/issue/CUS-251/pwas-are-getting-auto-logged-out-on-app-quit

## Issue

End users of Hercules apps (especially backgrounded PWAs on iOS) are silently signed out after roughly an hour of idle, even though their refresh token is still valid for 30 days. Re-authenticating then takes 30 to 45 seconds because the user has to walk the full OIDC flow again.

CUS-251 reports this for `robert_buntin@sil.org` across two iPhones, an iPad, an Android, and three laptops on multiple networks. The customer's app is `Read Reflect React` (`01KEBNN4HR04GN68DGSD4FA8Q2`), which has `HERCULES_OIDC_AUTHORITY` and `HERCULES_OIDC_CLIENT_ID` configured (so it uses Hercules Auth + Convex like the standard template).

## Root Cause

`packages/auth/src/convex-react/ConvexProviderWithHercules.tsx` ignores Convex's `{ forceRefreshToken: true }` and returns the same in-memory `idToken` regardless. Convex calls `fetchAccessToken({ forceRefreshToken: true })` when its websocket gets an auth error (typical signal: access token expired). With the flag ignored, Convex receives the stale token, the server rejects it again, and after `MAX_TOKEN_CONFIRMATION_ATTEMPTS` Convex clears auth and reports the user as unauthenticated. The customer-visible behavior is a forced full re-login.

The bug is a regression introduced in commit `93ef0cf chore(deps): upgrade Convex to 1.29.3 and React to 19` (2025-11-22). Prior to that commit, the bridge correctly called `signinSilent()` when `forceRefreshToken` was true. The upgrade commented out the call and renamed the parameter to `_ignore`. Diff before that commit:

```ts
if (forceRefreshToken) {
  const user = await signinSilent();
  return user?.id_token ?? null;
}
return idToken ?? null;
```

This call exchanges the still-valid refresh token (30 day sliding window per Hercules Auth policy) for a fresh `id_token`. Without it, the access token's 1 hour TTL becomes the effective session lifetime, which exactly matches the customer's reported symptom of being signed out after about an hour idle.

The Convex docs (`convex/src/react/ConvexAuthState.test.tsx`) explicitly require: "Make sure to fetch a new token when `forceRefreshToken` is true."

## Fix

Restore the `signinSilent()` call on `forceRefreshToken`. Variable shadowing of the outer `user` is avoided by binding the result to `refreshed`. The outer try/catch already handles a thrown `signinSilent` error by returning `null`, which lets Convex enter its no-auth fallback rather than retrying with a stale token.

Bumped via changeset as a patch (`@usehercules/auth` 1.0.42 to 1.0.43). Once published, every customer app picks the fix up on next install or build.

## Test plan

- [x] `pnpm --filter @usehercules/auth test` passes (19/19)
- [x] `pnpm --filter @usehercules/auth build` succeeds with type emit
- [x] `prettier --check` clean
- [ ] Smoke test against a Hercules Auth + Convex app: stop the dev server for an hour, resume the foregrounded tab, verify Convex queries continue without a forced re-login
- [ ] iOS PWA smoke test: install to home screen, leave for 1+ hour, reopen, verify no full re-login is triggered