### PR TITLE
fix(vite): exclude all @react-three/* companion imports from tagger

### DIFF
--- a/.changeset/fix-r3f-companion-tagger.md
+++ b/.changeset/fix-r3f-companion-tagger.md
@@ -1,0 +1,5 @@
+---
+"@usehercules/vite": patch
+---
+
+Fix component-tagger injecting `data-hercules-name` onto JSX from `@react-three/*` companion packages (postprocessing, cannon, rapier, xr), which crashed React Three Fiber's reconciler with `R3F: Cannot set 'data-hercules-name'`. The import-source filter now covers every `@react-three/*` package except `@react-three/fiber`, whose `<Canvas>` renders a real DOM canvas where data attributes are valid.

--- a/packages/vite/src/component-tagger.ts
+++ b/packages/vite/src/component-tagger.ts
@@ -227,14 +227,19 @@ export class ComponentTagger {
       // Dynamic import estree-walker
       const { walk } = await import("estree-walker");
 
-      // First pass: collect drei imports
+      // First pass: collect @react-three/* companion-package imports (drei,
+      // postprocessing, cannon, rapier, xr). Their named exports render into
+      // the R3F reconciler, which trips on injected data-hercules-name.
+      // @react-three/fiber's <Canvas> is excluded since it renders a real
+      // DOM canvas where data-* attributes are valid.
       walk(ast as any, {
         enter(node) {
           if (node.type === "ImportDeclaration") {
             const source = node.source?.value;
             if (
               typeof source === "string" &&
-              source.includes("@react-three/drei")
+              source.startsWith("@react-three/") &&
+              source !== "@react-three/fiber"
             ) {
               node.specifiers.forEach((spec: any) => {
                 if (spec.type === "ImportSpecifier") {


### PR DESCRIPTION
https://linear.app/hercules-app/issue/CUS-336/threejs-error-due-to-data-attribute-on-elements

## Summary

The Hercules App Builder element-inspector data attributes (`data-hercules-id` + `data-hercules-name`) are injected by `@usehercules/vite`'s component-tagger Vite plugin at JSX transform time. The plugin already excludes `@react-three/fiber` intrinsics (lowercase `<mesh>`, `<group>`, etc) via a static set and `@react-three/drei` named imports via an import-source scan, but it tags every other capitalized React component imported from `@react-three/*` companion packages.

Customer CUS-336 hit this with a cinematic Three.js scene using `@react-three/postprocessing` (`EffectComposer`, `Bloom`, `Vignette`, `ChromaticAberration`). Those components forward their props onto a `<primitive>` inside the R3F reconciler. R3F's `applyProps` splits `data-hercules-name` on `-` and tries to walk `obj.data.hercules.name` on the underlying postprocessing.js Effect, which throws `R3F: Cannot set "data-hercules-name". Ensure it is an object before setting "hercules-name".` Same failure mode for `@react-three/cannon`, `@react-three/rapier`, `@react-three/xr` (the agent prompt at `packages/agent/src/prompt/040-frontend.ts:39` explicitly recommends `@react-three/cannon` for 3D physics, so cannon-using apps would also blank).

## Fix

Widen the first-pass import-source filter from `source.includes("@react-three/drei")` to `source.startsWith("@react-three/") && source !== "@react-three/fiber"`. This treats every `@react-three/*` companion package the same way drei is already treated. `@react-three/fiber` is explicitly excluded because its only JSX-shaped export is `<Canvas>`, which renders a real DOM canvas where data-* attributes are valid (and useful for the inspector).

The set of intrinsics that R3F itself recognizes (lowercase `<mesh>`, etc) is already covered by the static `threeFiberElems` set; the broader filter only matters for capitalized named imports from companion packages.

## Test plan

- [ ] Customer 01KRFZ6S4MWXFXVD7VQ72B2QE3 thread 01KRFZ6SA5G0WGFFN1A61K2VYA: rebuild after publishing, confirm the R3F canvas mounts and the F1 tunnel scene renders without "Cannot set 'data-hercules-name'"
- [ ] Build still succeeds and no other R3F app loses its inspector targeting (the inspector targets DOM elements via `data-hercules-id`; this fix only suppresses data attributes on JSX that renders into the Three.js reconciler, never on DOM JSX)
- [ ] An app that uses `<Canvas>` from `@react-three/fiber` still gets `data-hercules-id` on the surrounding container/wrapper components so it remains inspectable

🤖 Generated with [Claude Code](https://claude.com/claude-code)