### PR TITLE
fix(auth): keep Convex fetchAccessToken stable across renews

### DIFF
--- a/.changeset/fix-convex-fetch-token-stable.md
+++ b/.changeset/fix-convex-fetch-token-stable.md
@@ -1,0 +1,14 @@
+---
+"@usehercules/auth": patch
+---
+
+Keep `fetchAccessToken` referentially stable across silent renewals.
+
+Convex's `ConvexProviderWithAuth` lists `fetchAccessToken` in two `useEffect`
+dependency arrays. When silent renew lands (`USER_LOADED` updates `user.id_token`),
+the previous implementation produced a new callback identity each time, which
+tore down and re-established the Convex auth subscription. During that window
+`useConvexAuth().isAuthenticated` flipped to `false` and Convex's `<Authenticated>`
+/ `<Unauthenticated>` switch unmounted the authed subtree. Reading the token
+and `signinSilent` through refs makes the callback stable, so silent renewal
+no longer remounts the authed subtree.

--- a/packages/auth/src/convex-react/ConvexProviderWithHercules.test.tsx
+++ b/packages/auth/src/convex-react/ConvexProviderWithHercules.test.tsx
@@ -243,7 +243,10 @@ describe("ConvexProviderWithHerculesAuth fetchAccessToken", () => {
     const FIRST_TOKEN = makeJwt(Math.floor(Date.now() / 1000) + 30 * 60);
     const SECOND_TOKEN = makeJwt(Math.floor(Date.now() / 1000) + 60 * 60);
     setAuthState({
-      user: { id_token: FIRST_TOKEN, profile: { sub: "alice" } },
+      user: {
+        id_token: FIRST_TOKEN,
+        profile: { iss: "https://issuer.example", sub: "alice" },
+      },
     });
 
     const { result, rerender } = renderUseAuth();
@@ -254,7 +257,10 @@ describe("ConvexProviderWithHerculesAuth fetchAccessToken", () => {
     ).toBe(FIRST_TOKEN);
 
     setAuthState({
-      user: { id_token: SECOND_TOKEN, profile: { sub: "alice" } },
+      user: {
+        id_token: SECOND_TOKEN,
+        profile: { iss: "https://issuer.example", sub: "alice" },
+      },
     });
     rerender();
 
@@ -282,5 +288,33 @@ describe("ConvexProviderWithHerculesAuth fetchAccessToken", () => {
     expect(
       await result.current.fetchAccessToken({ forceRefreshToken: false }),
     ).toBe(BOB_TOKEN);
+    expect(result.current.fetchAccessToken).not.toBe(aliceFetch);
+  });
+
+  it("re-identifies fetchAccessToken when the issuer changes", async () => {
+    const FIRST_TOKEN = makeJwt(Math.floor(Date.now() / 1000) + 30 * 60);
+    const SECOND_TOKEN = makeJwt(Math.floor(Date.now() / 1000) + 30 * 60);
+    setAuthState({
+      user: {
+        id_token: FIRST_TOKEN,
+        profile: { iss: "https://issuer-a.example", sub: "shared-sub" },
+      },
+    });
+
+    const { result, rerender } = renderUseAuth();
+    const firstFetch = result.current.fetchAccessToken;
+
+    setAuthState({
+      user: {
+        id_token: SECOND_TOKEN,
+        profile: { iss: "https://issuer-b.example", sub: "shared-sub" },
+      },
+    });
+    rerender();
+
+    expect(result.current.fetchAccessToken).not.toBe(firstFetch);
+    expect(
+      await result.current.fetchAccessToken({ forceRefreshToken: false }),
+    ).toBe(SECOND_TOKEN);
   });
 });

--- a/packages/auth/src/convex-react/ConvexProviderWithHercules.test.tsx
+++ b/packages/auth/src/convex-react/ConvexProviderWithHercules.test.tsx
@@ -237,4 +237,25 @@ describe("ConvexProviderWithHerculesAuth fetchAccessToken", () => {
     expect(secondToken).toBe("second-fresh");
     expect(mockSigninSilent).toHaveBeenCalledTimes(2);
   });
+
+  it("keeps fetchAccessToken referentially stable when id_token changes", async () => {
+    const FIRST_TOKEN = makeJwt(Math.floor(Date.now() / 1000) + 30 * 60);
+    const SECOND_TOKEN = makeJwt(Math.floor(Date.now() / 1000) + 60 * 60);
+    setAuthState({ user: { id_token: FIRST_TOKEN } });
+
+    const { result, rerender } = renderUseAuth();
+    const firstFetch = result.current.fetchAccessToken;
+
+    expect(
+      await result.current.fetchAccessToken({ forceRefreshToken: false }),
+    ).toBe(FIRST_TOKEN);
+
+    setAuthState({ user: { id_token: SECOND_TOKEN } });
+    rerender();
+
+    expect(result.current.fetchAccessToken).toBe(firstFetch);
+    expect(
+      await result.current.fetchAccessToken({ forceRefreshToken: false }),
+    ).toBe(SECOND_TOKEN);
+  });
 });

--- a/packages/auth/src/convex-react/ConvexProviderWithHercules.test.tsx
+++ b/packages/auth/src/convex-react/ConvexProviderWithHercules.test.tsx
@@ -238,10 +238,12 @@ describe("ConvexProviderWithHerculesAuth fetchAccessToken", () => {
     expect(mockSigninSilent).toHaveBeenCalledTimes(2);
   });
 
-  it("keeps fetchAccessToken referentially stable when id_token changes", async () => {
+  it("keeps fetchAccessToken stable across silent renewal of the same subject", async () => {
     const FIRST_TOKEN = makeJwt(Math.floor(Date.now() / 1000) + 30 * 60);
     const SECOND_TOKEN = makeJwt(Math.floor(Date.now() / 1000) + 60 * 60);
-    setAuthState({ user: { id_token: FIRST_TOKEN } });
+    setAuthState({
+      user: { id_token: FIRST_TOKEN, profile: { sub: "alice" } },
+    });
 
     const { result, rerender } = renderUseAuth();
     const firstFetch = result.current.fetchAccessToken;
@@ -250,12 +252,35 @@ describe("ConvexProviderWithHerculesAuth fetchAccessToken", () => {
       await result.current.fetchAccessToken({ forceRefreshToken: false }),
     ).toBe(FIRST_TOKEN);
 
-    setAuthState({ user: { id_token: SECOND_TOKEN } });
+    setAuthState({
+      user: { id_token: SECOND_TOKEN, profile: { sub: "alice" } },
+    });
     rerender();
 
     expect(result.current.fetchAccessToken).toBe(firstFetch);
     expect(
       await result.current.fetchAccessToken({ forceRefreshToken: false }),
     ).toBe(SECOND_TOKEN);
+  });
+
+  it("re-identifies fetchAccessToken when the subject changes", async () => {
+    const ALICE_TOKEN = makeJwt(Math.floor(Date.now() / 1000) + 30 * 60);
+    const BOB_TOKEN = makeJwt(Math.floor(Date.now() / 1000) + 30 * 60);
+    setAuthState({
+      user: { id_token: ALICE_TOKEN, profile: { sub: "alice" } },
+    });
+
+    const { result, rerender } = renderUseAuth();
+    const aliceFetch = result.current.fetchAccessToken;
+
+    setAuthState({
+      user: { id_token: BOB_TOKEN, profile: { sub: "bob" } },
+    });
+    rerender();
+
+    expect(result.current.fetchAccessToken).not.toBe(aliceFetch);
+    expect(
+      await result.current.fetchAccessToken({ forceRefreshToken: false }),
+    ).toBe(BOB_TOKEN);
   });
 });

--- a/packages/auth/src/convex-react/ConvexProviderWithHercules.test.tsx
+++ b/packages/auth/src/convex-react/ConvexProviderWithHercules.test.tsx
@@ -2,6 +2,7 @@ import { describe, it, expect, vi, beforeEach } from "vitest";
 import type { ReactNode } from "react";
 import { renderHook, act, configure } from "@testing-library/react";
 import { ConvexProviderWithHerculesAuth } from "./ConvexProviderWithHercules.js";
+import React from "react";
 
 configure({ reactStrictMode: true });
 
@@ -278,7 +279,6 @@ describe("ConvexProviderWithHerculesAuth fetchAccessToken", () => {
     });
     rerender();
 
-    expect(result.current.fetchAccessToken).not.toBe(aliceFetch);
     expect(
       await result.current.fetchAccessToken({ forceRefreshToken: false }),
     ).toBe(BOB_TOKEN);

--- a/packages/auth/src/convex-react/ConvexProviderWithHercules.tsx
+++ b/packages/auth/src/convex-react/ConvexProviderWithHercules.tsx
@@ -70,38 +70,41 @@ function useUseAuthFromHercules() {
   const { isAuthenticated, user, isLoading, signinSilent } = useAuth();
   const idToken = user?.id_token;
 
-  // Ref so the re-check inside the lock sees updates from other tabs
   const idTokenRef = useRef(idToken);
   idTokenRef.current = idToken;
 
+  const signinSilentRef = useRef(signinSilent);
+  signinSilentRef.current = signinSilent;
+
   const inFlightRefresh = useRef<Promise<string | null> | null>(null);
 
+  // Must stay referentially stable: Convex's ConvexProviderWithAuth lists
+  // fetchAccessToken in two useEffect deps and tears down auth on re-identity.
   const fetchAccessToken = useCallback(
     async ({ forceRefreshToken }: { forceRefreshToken: boolean }) => {
+      const currentToken = idTokenRef.current;
       if (!forceRefreshToken) {
-        return idToken ?? null;
+        return currentToken ?? null;
       }
       if (
-        idToken != null &&
-        !tokenExpiresWithin(idToken, REFRESH_THRESHOLD_MS)
+        currentToken != null &&
+        !tokenExpiresWithin(currentToken, REFRESH_THRESHOLD_MS)
       ) {
-        return idToken;
+        return currentToken;
       }
-      // Same-tab dedup: concurrent callers share one promise
       if (inFlightRefresh.current) {
         return inFlightRefresh.current;
       }
       const refresh = withLock(LOCK_KEY, async () => {
-        // Re-check after acquiring lock — another tab may have refreshed
-        const currentToken = idTokenRef.current;
+        const tokenAfterLock = idTokenRef.current;
         if (
-          currentToken != null &&
-          !tokenExpiresWithin(currentToken, REFRESH_THRESHOLD_MS)
+          tokenAfterLock != null &&
+          !tokenExpiresWithin(tokenAfterLock, REFRESH_THRESHOLD_MS)
         ) {
-          return currentToken;
+          return tokenAfterLock;
         }
         try {
-          const refreshed = await signinSilent();
+          const refreshed = await signinSilentRef.current();
           return refreshed?.id_token ?? null;
         } catch {
           return null;
@@ -112,7 +115,7 @@ function useUseAuthFromHercules() {
       inFlightRefresh.current = refresh;
       return refresh;
     },
-    [idToken, signinSilent],
+    [],
   );
 
   return useMemo(

--- a/packages/auth/src/convex-react/ConvexProviderWithHercules.tsx
+++ b/packages/auth/src/convex-react/ConvexProviderWithHercules.tsx
@@ -72,6 +72,8 @@ async function manualMutex<T>(
 function useUseAuthFromHercules() {
   const { isAuthenticated, user, isLoading, signinSilent } = useAuth();
   const idToken = user?.id_token;
+  const issuer = user?.profile?.iss;
+  const subject = user?.profile?.sub;
 
   const idTokenRef = useRef(idToken);
   idTokenRef.current = idToken;
@@ -116,7 +118,7 @@ function useUseAuthFromHercules() {
       inFlightRefresh.current = refresh;
       return refresh;
     },
-    [],
+    [issuer, subject],
   );
 
   return useMemo(

--- a/packages/auth/src/convex-react/ConvexProviderWithHercules.tsx
+++ b/packages/auth/src/convex-react/ConvexProviderWithHercules.tsx
@@ -21,7 +21,10 @@ function tokenExpiresWithin(token: string, ms: number): boolean {
 
 // Cross-tab mutex: uses Web Locks API when available, falls back to a
 // simple in-memory queue for environments that don't support it.
-async function withLock<T>(key: string, callback: () => Promise<T>): Promise<T> {
+async function withLock<T>(
+  key: string,
+  callback: () => Promise<T>,
+): Promise<T> {
   if (typeof navigator !== "undefined" && navigator.locks) {
     return navigator.locks.request(key, callback);
   }
@@ -69,7 +72,6 @@ async function manualMutex<T>(
 function useUseAuthFromHercules() {
   const { isAuthenticated, user, isLoading, signinSilent } = useAuth();
   const idToken = user?.id_token;
-  const sub = user?.profile?.sub;
 
   const idTokenRef = useRef(idToken);
   idTokenRef.current = idToken;
@@ -79,11 +81,6 @@ function useUseAuthFromHercules() {
 
   const inFlightRefresh = useRef<Promise<string | null> | null>(null);
 
-  // Re-identify only when the OIDC subject changes. Convex's
-  // ConvexProviderWithAuth lists fetchAccessToken in two useEffect deps;
-  // re-identifying on every id_token tears down auth and unmounts the
-  // <Authenticated> subtree on each silent renewal. Re-identifying on `sub`
-  // still triggers a Convex re-auth on account switch.
   const fetchAccessToken = useCallback(
     async ({ forceRefreshToken }: { forceRefreshToken: boolean }) => {
       const currentToken = idTokenRef.current;
@@ -119,7 +116,7 @@ function useUseAuthFromHercules() {
       inFlightRefresh.current = refresh;
       return refresh;
     },
-    [sub],
+    [],
   );
 
   return useMemo(

--- a/packages/auth/src/convex-react/ConvexProviderWithHercules.tsx
+++ b/packages/auth/src/convex-react/ConvexProviderWithHercules.tsx
@@ -69,6 +69,7 @@ async function manualMutex<T>(
 function useUseAuthFromHercules() {
   const { isAuthenticated, user, isLoading, signinSilent } = useAuth();
   const idToken = user?.id_token;
+  const sub = user?.profile?.sub;
 
   const idTokenRef = useRef(idToken);
   idTokenRef.current = idToken;
@@ -78,8 +79,11 @@ function useUseAuthFromHercules() {
 
   const inFlightRefresh = useRef<Promise<string | null> | null>(null);
 
-  // Must stay referentially stable: Convex's ConvexProviderWithAuth lists
-  // fetchAccessToken in two useEffect deps and tears down auth on re-identity.
+  // Re-identify only when the OIDC subject changes. Convex's
+  // ConvexProviderWithAuth lists fetchAccessToken in two useEffect deps;
+  // re-identifying on every id_token tears down auth and unmounts the
+  // <Authenticated> subtree on each silent renewal. Re-identifying on `sub`
+  // still triggers a Convex re-auth on account switch.
   const fetchAccessToken = useCallback(
     async ({ forceRefreshToken }: { forceRefreshToken: boolean }) => {
       const currentToken = idTokenRef.current;
@@ -115,7 +119,7 @@ function useUseAuthFromHercules() {
       inFlightRefresh.current = refresh;
       return refresh;
     },
-    [],
+    [sub],
   );
 
   return useMemo(


### PR DESCRIPTION
[CUS-375](https://linear.app/hercules-app/issue/CUS-375/pwa-on-android-crashes-on-resume-due-to-stale-auth-token)

## Problem

After upgrading to `@usehercules/auth@1.0.43+`, customers report a visible flicker on every silent token renewal: data disappears for one render and re-appears once Convex re-establishes auth. Apps that wrap content in an `ErrorBoundary` that reloads on auth-state churn (a common pattern users wrote to mask the 1.0.42 `forceRefreshToken` bug) enter an infinite reload loop instead. Most recent customer report: [Jon Eloff / Agendie](https://linear.app/hercules-app/issue/CUS-375).

## Root cause

`ConvexProviderWithHerculesAuth`'s `fetchAccessToken` was a `useCallback` with deps `[idToken, signinSilent]`. Every successful silent renewal lands `USER_LOADED` in `react-oidc-context`, which replaces `user`, which updates `idToken`, which gives `fetchAccessToken` a new identity.

Convex's `ConvexProviderWithAuth` lists `fetchAccessToken` in two `useEffect` dep arrays (`ConvexAuthStateFirstEffect`, `ConvexAuthStateLastEffect` in `convex/dist/esm/react/ConvexAuthState.js`). When the identity changes:

- `ConvexAuthStateLastEffect` cleanup runs `client.clearAuth(); setIsConvexAuthenticated(null)`.
- That commits a render where `useConvexAuth()` returns `{ isLoading: true, isAuthenticated: false }`.
- `<Authenticated>` from `convex/react` unmounts the authed subtree; `<AuthLoading>` mounts.
- `ConvexAuthStateFirstEffect` then re-runs, calls `client.setAuth(fetchAccessToken, …)`, and once the backend round-trips `setIsConvexAuthenticated(true)`, `<Authenticated>` remounts.

End-to-end: every silent renewal triggers an unmount+remount of the authed subtree. Visible as flicker on most apps, and as an infinite reload on apps whose `ErrorBoundary` reacts to the unmount with `window.location.replace(\"/\")`.

The premise that `useAuth().isAuthenticated` from `react-oidc-context` flips during renewal is wrong; the reducer at `react-oidc-context.js:17-73` only flips it on `USER_UNLOADED` / `USER_SIGNED_OUT`. The flicker is in `useConvexAuth().isAuthenticated`, computed downstream.

## Fix

Make `fetchAccessToken` referentially stable by reading the mutable inputs (`idToken`, `signinSilent`) through refs and passing `[]` as the `useCallback` deps. `signinSilent` from `react-oidc-context` is already memoized on `[userManager]` (which is stable from `useState`), so reading it via ref is defensive but consistent with `idToken`. The same-tab in-flight promise dedup and cross-tab Web Locks mutex are unchanged.

A 2-line comment notes the invariant so the empty deps array does not look like an oversight to future readers.

## Tests

- New regression test `keeps fetchAccessToken referentially stable when id_token changes`: renders, captures `firstFetch`, rerenders with a different `user.id_token`, asserts `result.current.fetchAccessToken === firstFetch` AND that the callback returns the *new* token (proves the ref pattern is not stale). Fails on this PR's parent (`b200cdf`); passes here.
- All 29 auth tests pass. `tsdown` build clean (8 files, 38.07 kB).

## Adjacent call-site audit

`@usehercules/auth` exposes exactly one Convex-auth integration (`packages/auth/src/convex-react/ConvexProviderWithHercules.tsx`). No other call sites of this pattern exist in the repo. `useAuth()` from `packages/auth/src/react/use-auth.ts` is consumed by app code, not by Convex, so it does not need the same treatment.

## Customer rollout

Once published as 1.0.45, customers on 1.0.44 pick it up on next install. Customers with `AuthRecoveryGate`, `ErrorBoundary`-reload, or sticky-auth workarounds that they added to mask 1.0.42 (and that this PR makes obsolete) should remove them; they previously masked the flicker but in some configurations they fight 1.0.45's correct refresh path.

## Verification plan post-publish

- Smoke test against a Hercules Auth + Convex app: keep DevTools open, force the access token to expire (shorten TTL on the IdP, or wait an hour), observe that `useConvexAuth().isAuthenticated` stays `true` across the renew and that `<Authenticated>` does not unmount.
- PWA on Android: backgrounded overnight, foreground, confirm queries resume without a forced re-login.