### PR TITLE
fix(vite): skip tagging R3F intrinsics that collide with DOM elements

### DIFF
--- a/.changeset/fix-r3f-dom-conflict-intrinsics.md
+++ b/.changeset/fix-r3f-dom-conflict-intrinsics.md
@@ -1,0 +1,20 @@
+---
+"@usehercules/vite": patch
+---
+
+Stop tagging R3F intrinsics whose names collide with DOM elements (`<line>`,
+`<path>`, `<audio>`, `<source>`, `<clippingGroup>`).
+
+The component tagger skipped tagging on R3F intrinsics like `<mesh>` and
+`<lineSegments>` whose lowercased names do not clash with any DOM element, but
+kept tagging `<line>` because `line` is also a real SVG element. Inside an R3F
+`<Canvas>`, `<line geometry={...}>` renders a `THREE.Line` via the R3F
+reconciler, which parses any `data-*` prop as a dash-separated key-path and
+attempts to walk `obj.data.hercules.name` on the underlying Three.js object.
+That throws `R3F: Cannot set "data-hercules-name". Ensure it is an object
+before setting "hercules-name".`, kills the WebGL context, and blanks the
+preview. Same story for `<path>`, `<audio>`, `<source>`, `<clippingGroup>`.
+
+Skip these names only in files that import from `@react-three/*` so that SVG
+charts and HTML media tags in non-R3F files are still selectable in the visual
+editor.

--- a/.changeset/fix-r3f-dom-conflict-intrinsics.md
+++ b/.changeset/fix-r3f-dom-conflict-intrinsics.md
@@ -15,6 +15,6 @@ That throws `R3F: Cannot set "data-hercules-name". Ensure it is an object
 before setting "hercules-name".`, kills the WebGL context, and blanks the
 preview. Same story for `<path>`, `<audio>`, `<source>`, `<clippingGroup>`.
 
-Skip these names only in files that import from `@react-three/*` so that SVG
-charts and HTML media tags in non-R3F files are still selectable in the visual
-editor.
+Skip these names only inside an R3F `<Canvas>` subtree so that SVG charts and
+HTML media tags in the same file (rendered outside any `<Canvas>`) are still
+selectable in the visual editor.

--- a/packages/vite/src/component-tagger.ts
+++ b/packages/vite/src/component-tagger.ts
@@ -285,13 +285,18 @@ export class ComponentTagger {
         },
       });
 
-      // Binding-aware check: does this JSX opening name resolve to a
-      // @react-three/fiber Canvas import (direct, aliased, or via namespace)
-      // in the CURRENT lexical scope? path.scope.getBinding follows the usual
-      // JavaScript scoping rules, so a function param / local var named
-      // "Canvas" that shadows the import returns the shadowing binding and
-      // we treat the subtree as DOM, not R3F.
-      const isCanvasReference = (name: any, scope: any): boolean => {
+      // Binding-aware check: does this JSX opening name resolve to a named
+      // export from a particular @react-three/* package in the CURRENT
+      // lexical scope? path.scope.getBinding follows the usual JavaScript
+      // scoping rules, so a function param or local var that shadows the
+      // import returns the shadowing binding and we correctly conclude that
+      // the subtree is not the imported component.
+      const resolvesToImport = (
+        name: any,
+        scope: any,
+        sourceModule: string,
+        importedName: string,
+      ): boolean => {
         if (!name) return false;
         if (name.type === "JSXIdentifier") {
           const binding = scope.getBinding(name.name);
@@ -303,8 +308,8 @@ export class ComponentTagger {
             bindingNode.importKind !== "type" &&
             bindingParent?.type === "ImportDeclaration" &&
             bindingParent.importKind !== "type" &&
-            bindingParent.source?.value === "@react-three/fiber" &&
-            bindingNode.imported?.name === "Canvas"
+            bindingParent.source?.value === sourceModule &&
+            bindingNode.imported?.name === importedName
           ) {
             return true;
           }
@@ -314,7 +319,7 @@ export class ComponentTagger {
           name.type === "JSXMemberExpression" &&
           name.object?.type === "JSXIdentifier" &&
           name.property?.type === "JSXIdentifier" &&
-          name.property.name === "Canvas"
+          name.property.name === importedName
         ) {
           const binding = scope.getBinding(name.object.name);
           if (!binding) return false;
@@ -324,7 +329,7 @@ export class ComponentTagger {
             bindingNode?.type === "ImportNamespaceSpecifier" &&
             bindingParent?.type === "ImportDeclaration" &&
             bindingParent.importKind !== "type" &&
-            bindingParent.source?.value === "@react-three/fiber"
+            bindingParent.source?.value === sourceModule
           ) {
             return true;
           }
@@ -332,28 +337,50 @@ export class ComponentTagger {
         return false;
       };
 
+      const isCanvasReference = (name: any, scope: any) =>
+        resolvesToImport(name, scope, "@react-three/fiber", "Canvas");
+      // drei's <Html> portals its children into the regular DOM (outside the
+      // WebGL canvas), so DOM-conflict intrinsics inside it must keep their
+      // tags. Track Html subtrees so we can suppress the canvas-subtree skip
+      // while we are inside one.
+      const isHtmlPortalReference = (name: any, scope: any) =>
+        resolvesToImport(name, scope, "@react-three/drei", "Html");
+
       // Capture dataAttribute for use in the walker
       const dataAttribute = this.dataAttribute;
 
       // Second pass: tag elements. canvasDepth tracks whether the current
-      // JSX node is nested inside an R3F <Canvas>; DOM-conflict intrinsics
+      // JSX node is nested inside an R3F <Canvas>; htmlPortalDepth tracks
+      // nesting inside a drei <Html> (which portals back to the DOM, so
+      // children there are real DOM elements again). DOM-conflict intrinsics
       // (<line>, <path>, <audio>, <source>, <clippingGroup>) are skipped
-      // only when canvasDepth > 0, so the same file can render ordinary
-      // SVG/HTML versions outside the canvas and keep them selectable in
-      // the visual editor. We use @babel/traverse here (not estree-walker)
-      // for path.scope.getBinding, which lets us resolve <Canvas> by lexical
-      // binding rather than by raw name and so respects shadowing scopes.
+      // only when canvasDepth > 0 AND we are not currently inside an Html
+      // portal, so the same file can render ordinary SVG/HTML versions
+      // outside the canvas (or inside a portal back to DOM) and keep them
+      // selectable in the visual editor. We use @babel/traverse here (not
+      // estree-walker) for path.scope.getBinding, which lets us resolve
+      // <Canvas>/<Html> by lexical binding rather than by raw name and so
+      // respects shadowing scopes.
       let canvasDepth = 0;
+      let htmlPortalDepth = 0;
       traverse(ast as any, {
         JSXElement: {
           enter(path: any) {
             if (isCanvasReference(path.node.openingElement?.name, path.scope)) {
               canvasDepth++;
+            } else if (
+              isHtmlPortalReference(path.node.openingElement?.name, path.scope)
+            ) {
+              htmlPortalDepth++;
             }
           },
           exit(path: any) {
             if (isCanvasReference(path.node.openingElement?.name, path.scope)) {
               canvasDepth--;
+            } else if (
+              isHtmlPortalReference(path.node.openingElement?.name, path.scope)
+            ) {
+              htmlPortalDepth--;
             }
           },
         },
@@ -387,7 +414,7 @@ export class ComponentTagger {
               elementName,
               threeDreiImportedElements,
               threeDreiNamespaces,
-              canvasDepth > 0,
+              canvasDepth > 0 && htmlPortalDepth === 0,
             );
 
             if (shouldTag) {

--- a/packages/vite/src/component-tagger.ts
+++ b/packages/vite/src/component-tagger.ts
@@ -261,9 +261,16 @@ export class ComponentTagger {
               source.startsWith("@react-three/") &&
               (node as any).importKind !== "type"
             ) {
+              const specifiers = node.specifiers ?? [];
+              const hasValueSpec =
+                specifiers.length === 0 ||
+                specifiers.some((spec: any) => spec.importKind !== "type");
+              if (!hasValueSpec) {
+                return;
+              }
               hasReactThreeImport = true;
               if (source !== "@react-three/fiber") {
-                node.specifiers.forEach((spec: any) => {
+                specifiers.forEach((spec: any) => {
                   if (spec.importKind === "type") {
                     return;
                   }

--- a/packages/vite/src/component-tagger.ts
+++ b/packages/vite/src/component-tagger.ts
@@ -1,7 +1,11 @@
 import path from "path";
 import { parse } from "@babel/parser";
+import _traverse from "@babel/traverse";
 import MagicString from "magic-string";
 import type { Plugin, ViteDevServer } from "vite";
+
+// @babel/traverse ships a CJS default-export, so unwrap it for ESM consumers.
+const traverse = ((_traverse as any).default ?? _traverse) as typeof _traverse;
 
 // Types
 export interface ComponentTaggerOptions {
@@ -239,25 +243,16 @@ export class ComponentTagger {
       let changedElementsCount = 0;
       const threeDreiImportedElements = new Set<string>();
       const threeDreiNamespaces = new Set<string>();
-      // Local identifiers that resolve to @react-three/fiber's Canvas
-      // (handles aliases via local.name). When JSX opens one of these, we
-      // are entering an R3F render subtree.
-      const canvasIdentifiers = new Set<string>();
-      // Local namespace identifiers for `import * as X from "@react-three/fiber"`.
-      // <X.Canvas> opens an R3F subtree.
-      const fiberNamespaces = new Set<string>();
 
       // Dynamic import estree-walker
       const { walk } = await import("estree-walker");
 
       // First pass: collect @react-three/* companion-package imports (drei,
       // postprocessing, cannon, rapier, xr). Their named exports render into
-      // the R3F reconciler, which trips on injected data-hercules-name.
-      // From @react-three/fiber we additionally track which local identifier
-      // refers to Canvas so the second pass can scope DOM-conflict skips
-      // (<line>, <path>, <audio>, <source>, <clippingGroup>) to JSX actually
-      // rendered inside an R3F Canvas subtree, leaving DOM/SVG usage in the
-      // same file taggable.
+      // the R3F reconciler, which trips on injected data-hercules-name. Also
+      // walk @react-three/fiber's import specifiers so the second pass can
+      // resolve a JSX <Canvas> reference back to the import via
+      // path.scope.getBinding (binding-aware, not just by name).
       walk(ast as any, {
         enter(node) {
           if (node.type === "ImportDeclaration") {
@@ -265,6 +260,7 @@ export class ComponentTagger {
             if (
               typeof source === "string" &&
               source.startsWith("@react-three/") &&
+              source !== "@react-three/fiber" &&
               (node as any).importKind !== "type"
             ) {
               const specifiers = node.specifiers ?? [];
@@ -274,54 +270,64 @@ export class ComponentTagger {
               if (!hasValueSpec) {
                 return;
               }
-              if (source === "@react-three/fiber") {
-                specifiers.forEach((spec: any) => {
-                  if (spec.importKind === "type") {
-                    return;
-                  }
-                  if (
-                    spec.type === "ImportSpecifier" &&
-                    spec.imported?.name === "Canvas"
-                  ) {
-                    canvasIdentifiers.add(spec.local.name);
-                  } else if (spec.type === "ImportNamespaceSpecifier") {
-                    fiberNamespaces.add(spec.local.name);
-                  }
-                });
-              } else {
-                specifiers.forEach((spec: any) => {
-                  if (spec.importKind === "type") {
-                    return;
-                  }
-                  if (spec.type === "ImportSpecifier") {
-                    threeDreiImportedElements.add(spec.local.name);
-                  } else if (spec.type === "ImportNamespaceSpecifier") {
-                    threeDreiNamespaces.add(spec.local.name);
-                  }
-                });
-              }
+              specifiers.forEach((spec: any) => {
+                if (spec.importKind === "type") {
+                  return;
+                }
+                if (spec.type === "ImportSpecifier") {
+                  threeDreiImportedElements.add(spec.local.name);
+                } else if (spec.type === "ImportNamespaceSpecifier") {
+                  threeDreiNamespaces.add(spec.local.name);
+                }
+              });
             }
           }
         },
       });
 
-      // True iff the given JSX opening name resolves to an R3F Canvas: either
-      // a direct identifier alias of @react-three/fiber's Canvas, or a
-      // `<Namespace.Canvas>` whose namespace was imported from fiber. Used to
-      // bracket canvasDepth in the second walk.
-      const isCanvasOpening = (name: any): boolean => {
+      // Binding-aware check: does this JSX opening name resolve to a
+      // @react-three/fiber Canvas import (direct, aliased, or via namespace)
+      // in the CURRENT lexical scope? path.scope.getBinding follows the usual
+      // JavaScript scoping rules, so a function param / local var named
+      // "Canvas" that shadows the import returns the shadowing binding and
+      // we treat the subtree as DOM, not R3F.
+      const isCanvasReference = (name: any, scope: any): boolean => {
         if (!name) return false;
         if (name.type === "JSXIdentifier") {
-          return canvasIdentifiers.has(name.name);
+          const binding = scope.getBinding(name.name);
+          if (!binding) return false;
+          const bindingNode = binding.path?.node;
+          const bindingParent = binding.path?.parent;
+          if (
+            bindingNode?.type === "ImportSpecifier" &&
+            bindingNode.importKind !== "type" &&
+            bindingParent?.type === "ImportDeclaration" &&
+            bindingParent.importKind !== "type" &&
+            bindingParent.source?.value === "@react-three/fiber" &&
+            bindingNode.imported?.name === "Canvas"
+          ) {
+            return true;
+          }
+          return false;
         }
         if (
           name.type === "JSXMemberExpression" &&
           name.object?.type === "JSXIdentifier" &&
-          fiberNamespaces.has(name.object.name) &&
           name.property?.type === "JSXIdentifier" &&
           name.property.name === "Canvas"
         ) {
-          return true;
+          const binding = scope.getBinding(name.object.name);
+          if (!binding) return false;
+          const bindingNode = binding.path?.node;
+          const bindingParent = binding.path?.parent;
+          if (
+            bindingNode?.type === "ImportNamespaceSpecifier" &&
+            bindingParent?.type === "ImportDeclaration" &&
+            bindingParent.importKind !== "type" &&
+            bindingParent.source?.value === "@react-three/fiber"
+          ) {
+            return true;
+          }
         }
         return false;
       };
@@ -331,17 +337,29 @@ export class ComponentTagger {
 
       // Second pass: tag elements. canvasDepth tracks whether the current
       // JSX node is nested inside an R3F <Canvas>; DOM-conflict intrinsics
-      // are skipped only when canvasDepth > 0 so the same file can render
-      // ordinary SVG/HTML <line>, <path>, <audio>, <source> outside the
-      // canvas and keep them selectable in the visual editor.
+      // (<line>, <path>, <audio>, <source>, <clippingGroup>) are skipped
+      // only when canvasDepth > 0, so the same file can render ordinary
+      // SVG/HTML versions outside the canvas and keep them selectable in
+      // the visual editor. We use @babel/traverse here (not estree-walker)
+      // for path.scope.getBinding, which lets us resolve <Canvas> by lexical
+      // binding rather than by raw name and so respects shadowing scopes.
       let canvasDepth = 0;
-      walk(ast as any, {
-        enter(node: any) {
-          if (node.type === "JSXElement" && isCanvasOpening(node.openingElement?.name)) {
-            canvasDepth++;
-          }
-          if (node.type === "JSXOpeningElement") {
-            const jsxNode = node;
+      traverse(ast as any, {
+        JSXElement: {
+          enter(path: any) {
+            if (isCanvasReference(path.node.openingElement?.name, path.scope)) {
+              canvasDepth++;
+            }
+          },
+          exit(path: any) {
+            if (isCanvasReference(path.node.openingElement?.name, path.scope)) {
+              canvasDepth--;
+            }
+          },
+        },
+        JSXOpeningElement: {
+          enter(path: any) {
+            const jsxNode = path.node;
             let elementName: string;
 
             if (jsxNode.name.type === "JSXIdentifier") {
@@ -382,12 +400,7 @@ export class ComponentTagger {
               magicString.appendLeft(endPosition, attributesString);
               changedElementsCount++;
             }
-          }
-        },
-        leave(node: any) {
-          if (node.type === "JSXElement" && isCanvasOpening(node.openingElement?.name)) {
-            canvasDepth--;
-          }
+          },
         },
       });
 

--- a/packages/vite/src/component-tagger.ts
+++ b/packages/vite/src/component-tagger.ts
@@ -258,11 +258,15 @@ export class ComponentTagger {
             const source = node.source?.value;
             if (
               typeof source === "string" &&
-              source.startsWith("@react-three/")
+              source.startsWith("@react-three/") &&
+              (node as any).importKind !== "type"
             ) {
               hasReactThreeImport = true;
               if (source !== "@react-three/fiber") {
                 node.specifiers.forEach((spec: any) => {
+                  if (spec.importKind === "type") {
+                    return;
+                  }
                   if (spec.type === "ImportSpecifier") {
                     threeDreiImportedElements.add(spec.local.name);
                   } else if (spec.type === "ImportNamespaceSpecifier") {

--- a/packages/vite/src/component-tagger.ts
+++ b/packages/vite/src/component-tagger.ts
@@ -180,12 +180,12 @@ function shouldTagElement(
   elementName: string,
   threeDreiImportedElements: Set<string>,
   threeDreiNamespaces: Set<string>,
-  hasReactThreeImport: boolean,
+  insideCanvasSubtree: boolean,
 ): boolean {
   if (threeFiberElems.has(elementName)) {
     return false;
   }
-  if (hasReactThreeImport && threeFiberDomConflictElems.has(elementName)) {
+  if (insideCanvasSubtree && threeFiberDomConflictElems.has(elementName)) {
     return false;
   }
   if (threeDreiImportedElements.has(elementName)) {
@@ -239,7 +239,13 @@ export class ComponentTagger {
       let changedElementsCount = 0;
       const threeDreiImportedElements = new Set<string>();
       const threeDreiNamespaces = new Set<string>();
-      let hasReactThreeImport = false;
+      // Local identifiers that resolve to @react-three/fiber's Canvas
+      // (handles aliases via local.name). When JSX opens one of these, we
+      // are entering an R3F render subtree.
+      const canvasIdentifiers = new Set<string>();
+      // Local namespace identifiers for `import * as X from "@react-three/fiber"`.
+      // <X.Canvas> opens an R3F subtree.
+      const fiberNamespaces = new Set<string>();
 
       // Dynamic import estree-walker
       const { walk } = await import("estree-walker");
@@ -247,11 +253,11 @@ export class ComponentTagger {
       // First pass: collect @react-three/* companion-package imports (drei,
       // postprocessing, cannon, rapier, xr). Their named exports render into
       // the R3F reconciler, which trips on injected data-hercules-name.
-      // @react-three/fiber's <Canvas> is excluded since it renders a real
-      // DOM canvas where data-* attributes are valid; we still record that
-      // the file imports from @react-three/* so the lowercased intrinsics
-      // that conflict with DOM names (<line>, <path>, <audio>, <source>) can
-      // be skipped only inside R3F files.
+      // From @react-three/fiber we additionally track which local identifier
+      // refers to Canvas so the second pass can scope DOM-conflict skips
+      // (<line>, <path>, <audio>, <source>, <clippingGroup>) to JSX actually
+      // rendered inside an R3F Canvas subtree, leaving DOM/SVG usage in the
+      // same file taggable.
       walk(ast as any, {
         enter(node) {
           if (node.type === "ImportDeclaration") {
@@ -268,8 +274,21 @@ export class ComponentTagger {
               if (!hasValueSpec) {
                 return;
               }
-              hasReactThreeImport = true;
-              if (source !== "@react-three/fiber") {
+              if (source === "@react-three/fiber") {
+                specifiers.forEach((spec: any) => {
+                  if (spec.importKind === "type") {
+                    return;
+                  }
+                  if (
+                    spec.type === "ImportSpecifier" &&
+                    spec.imported?.name === "Canvas"
+                  ) {
+                    canvasIdentifiers.add(spec.local.name);
+                  } else if (spec.type === "ImportNamespaceSpecifier") {
+                    fiberNamespaces.add(spec.local.name);
+                  }
+                });
+              } else {
                 specifiers.forEach((spec: any) => {
                   if (spec.importKind === "type") {
                     return;
@@ -286,12 +305,41 @@ export class ComponentTagger {
         },
       });
 
+      // True iff the given JSX opening name resolves to an R3F Canvas: either
+      // a direct identifier alias of @react-three/fiber's Canvas, or a
+      // `<Namespace.Canvas>` whose namespace was imported from fiber. Used to
+      // bracket canvasDepth in the second walk.
+      const isCanvasOpening = (name: any): boolean => {
+        if (!name) return false;
+        if (name.type === "JSXIdentifier") {
+          return canvasIdentifiers.has(name.name);
+        }
+        if (
+          name.type === "JSXMemberExpression" &&
+          name.object?.type === "JSXIdentifier" &&
+          fiberNamespaces.has(name.object.name) &&
+          name.property?.type === "JSXIdentifier" &&
+          name.property.name === "Canvas"
+        ) {
+          return true;
+        }
+        return false;
+      };
+
       // Capture dataAttribute for use in the walker
       const dataAttribute = this.dataAttribute;
 
-      // Second pass: tag elements
+      // Second pass: tag elements. canvasDepth tracks whether the current
+      // JSX node is nested inside an R3F <Canvas>; DOM-conflict intrinsics
+      // are skipped only when canvasDepth > 0 so the same file can render
+      // ordinary SVG/HTML <line>, <path>, <audio>, <source> outside the
+      // canvas and keep them selectable in the visual editor.
+      let canvasDepth = 0;
       walk(ast as any, {
         enter(node: any) {
+          if (node.type === "JSXElement" && isCanvasOpening(node.openingElement?.name)) {
+            canvasDepth++;
+          }
           if (node.type === "JSXOpeningElement") {
             const jsxNode = node;
             let elementName: string;
@@ -321,7 +369,7 @@ export class ComponentTagger {
               elementName,
               threeDreiImportedElements,
               threeDreiNamespaces,
-              hasReactThreeImport,
+              canvasDepth > 0,
             );
 
             if (shouldTag) {
@@ -334,6 +382,11 @@ export class ComponentTagger {
               magicString.appendLeft(endPosition, attributesString);
               changedElementsCount++;
             }
+          }
+        },
+        leave(node: any) {
+          if (node.type === "JSXElement" && isCanvasOpening(node.openingElement?.name)) {
+            canvasDepth--;
           }
         },
       });

--- a/packages/vite/src/component-tagger.ts
+++ b/packages/vite/src/component-tagger.ts
@@ -163,13 +163,29 @@ const threeFiberElems = new Set([
   "colorShiftMaterial",
 ]);
 
+// Keep: Three.js objects whose lowercased R3F intrinsic names also exist as
+// real DOM/SVG element names (<line>, <path>, <audio>, <source>). We only skip
+// tagging on these when the file imports from @react-three/* so non-R3F files
+// can still tag their SVG/HTML usage.
+const threeFiberDomConflictElems = new Set([
+  "line",
+  "path",
+  "audio",
+  "source",
+  "clippingGroup",
+]);
+
 // Keep: Check if element should be tagged
 function shouldTagElement(
   elementName: string,
   threeDreiImportedElements: Set<string>,
   threeDreiNamespaces: Set<string>,
+  hasReactThreeImport: boolean,
 ): boolean {
   if (threeFiberElems.has(elementName)) {
+    return false;
+  }
+  if (hasReactThreeImport && threeFiberDomConflictElems.has(elementName)) {
     return false;
   }
   if (threeDreiImportedElements.has(elementName)) {
@@ -223,6 +239,7 @@ export class ComponentTagger {
       let changedElementsCount = 0;
       const threeDreiImportedElements = new Set<string>();
       const threeDreiNamespaces = new Set<string>();
+      let hasReactThreeImport = false;
 
       // Dynamic import estree-walker
       const { walk } = await import("estree-walker");
@@ -231,23 +248,28 @@ export class ComponentTagger {
       // postprocessing, cannon, rapier, xr). Their named exports render into
       // the R3F reconciler, which trips on injected data-hercules-name.
       // @react-three/fiber's <Canvas> is excluded since it renders a real
-      // DOM canvas where data-* attributes are valid.
+      // DOM canvas where data-* attributes are valid; we still record that
+      // the file imports from @react-three/* so the lowercased intrinsics
+      // that conflict with DOM names (<line>, <path>, <audio>, <source>) can
+      // be skipped only inside R3F files.
       walk(ast as any, {
         enter(node) {
           if (node.type === "ImportDeclaration") {
             const source = node.source?.value;
             if (
               typeof source === "string" &&
-              source.startsWith("@react-three/") &&
-              source !== "@react-three/fiber"
+              source.startsWith("@react-three/")
             ) {
-              node.specifiers.forEach((spec: any) => {
-                if (spec.type === "ImportSpecifier") {
-                  threeDreiImportedElements.add(spec.local.name);
-                } else if (spec.type === "ImportNamespaceSpecifier") {
-                  threeDreiNamespaces.add(spec.local.name);
-                }
-              });
+              hasReactThreeImport = true;
+              if (source !== "@react-three/fiber") {
+                node.specifiers.forEach((spec: any) => {
+                  if (spec.type === "ImportSpecifier") {
+                    threeDreiImportedElements.add(spec.local.name);
+                  } else if (spec.type === "ImportNamespaceSpecifier") {
+                    threeDreiNamespaces.add(spec.local.name);
+                  }
+                });
+              }
             }
           }
         },
@@ -288,6 +310,7 @@ export class ComponentTagger {
               elementName,
               threeDreiImportedElements,
               threeDreiNamespaces,
+              hasReactThreeImport,
             );
 
             if (shouldTag) {


### PR DESCRIPTION
Linear: https://linear.app/hercules-app/issue/CUS-429/blank-screen-after-package-changes-r3fwebgl

## Summary

The component tagger unconditionally tagged R3F intrinsics that share a lowercased name with a real DOM/SVG element (`<line>`, `<path>`, `<audio>`, `<source>`, `<clippingGroup>`). Inside an R3F `<Canvas>` those JSX symbols render real Three.js objects, and R3F's reconciler parses any `data-*` prop as a dash-separated key-path, attempting to walk `obj.data.hercules.name` on the underlying object. It throws:

```
Uncaught Error: R3F: Cannot set "data-hercules-name".
Ensure it is an object before setting "hercules-name".
```

…then loses the WebGL context and blanks the preview.

The fix is structured in two layers:

1. A new `threeFiberDomConflictElems` set with the lowercased intrinsics whose names also exist as DOM/SVG elements.
2. **Canvas-subtree-scoped tagging.** The walker tracks which local identifiers in the file resolve to `Canvas` from `@react-three/fiber` (including aliases via `import { Canvas as Foo }` and namespace imports `import * as Three from "@react-three/fiber"` with `<Three.Canvas>`). A `canvasDepth` counter is incremented when JSX enters such an element and decremented on leave. DOM-conflict intrinsics are skipped only when `canvasDepth > 0`, so the same file can render an SVG `<line>` or an HTML `<audio>` outside the Canvas and keep them selectable in the visual editor.

Type-only imports are ignored when collecting Canvas/drei identifiers: both top-level `import type { ThreeElements } from "@react-three/fiber"` and specifier-level `import { type ThreeElements, Canvas } from "@react-three/fiber"` are filtered, since they are erased at runtime. A side-effect-only import (`import "@react-three/fiber"`) binds no Canvas, so it never opens a Canvas subtree.

Companion fix #41 (2026-05-15) covered `@react-three/drei`/`postprocessing`/`cannon`/`rapier`/`xr` named imports. This PR closes the remaining hole around bare R3F intrinsics that share their name with DOM elements without regressing tagging for normal SVG/HTML usage anywhere else in the same file.

## Evidence (CUS-429)

Customer thread `01KS1G650KGCV4GJA5QCPJ953Y`, message `01KS1G67VXFC1TGRC74YTQPXGB`, `read_logs` output at part 101:

```
[Runtime Error] {message: Uncaught Error: R3F: Cannot set "data-hercules-name".
  Ensure it is an object before setting "hercules-name".,
  filename: https://01ks1g64wjdt2955wa6z58f09x.hercules-dev.com/node_modules/.vite/deps/chunk-WLGJYZUG.js?v=1ed57057,
  lineno: 699, ...}
[Runtime Error] {message: Uncaught TypeError: Cannot convert undefined or null to object, ...}
LOG: THREE.WebGLRenderer: Context Lost.
```

The agent's `Scene3D.tsx` at the time of the crash used `<line geometry={points}><lineBasicMaterial /></line>` for axes and orbit lines (parts 8, 96 of the message in prod). `lineBasicMaterial` was already skipped via `threeFiberElems`; `line` was not.

Container `f755e688e48483827eaef4ee20734f391ada1ba543a6532acfa604c1713607db` (app `a0331af6-c70e-4795-b67f-b1aa40ccd713`) was stable across the 70+ minutes around the failure, so the blank screen was not a dev-machine outage. The dev server cache had already been corrupted by the first crash, which is why removing the R3F packages later did not recover the page.

## Test plan

Smoke-tested via `tsx smoke.ts` (not committed) against 17 fixtures, 43/43 assertions. Each fixture covers a different file shape; expectations are over whether the tagger appended `data-component-id="..."` and `data-hercules-name="..."` to the opening tag.

- [x] R3F file with `<line>`, `<mesh>`, `<sphereGeometry>`, `<Canvas>`: only `<Canvas>` is tagged
- [x] Pure SVG file (no R3F import) with `<svg>`, `<line>`, `<path>`: all three tagged
- [x] R3F file importing `Line` from `@react-three/drei`: both capital `<Line>` and bare `<line>` (inside Canvas) skipped
- [x] R3F file with `<audio>`, `<source>`, `<path>` inside Canvas: all skipped
- [x] Non-R3F file with `<audio>`, `<source>`, `<path>`: all tagged
- [x] `import type { ThreeElements } from "@react-three/fiber"`: file is NOT R3F, DOM intrinsics tagged
- [x] `import type * as Three from "@react-three/fiber"`: file is NOT R3F
- [x] `import { type ThreeElements } from "@react-three/fiber"` (specifier-level type-only): file is NOT R3F
- [x] `import { type ThreeElements, Canvas } from "@react-three/fiber"` (mixed): file IS R3F, Canvas subtree skip applies
- [x] **Mixed file**: SVG `<line>` outside Canvas tagged, R3F `<line>` inside Canvas skipped (1 `data-hercules-name="line"` occurrence, not 2)
- [x] **Aliased Canvas** (`import { Canvas as ThreeCanvas }`): SVG line outside tagged, R3F line inside ThreeCanvas skipped
- [x] **Namespace Canvas** (`import * as Three`; `<Three.Canvas>`): SVG path outside tagged, R3F path inside skipped
- [x] Nested Canvas: `<line>` deep inside `<Canvas><group><line /></group></Canvas>` still skipped
- [x] **Side-effect-only import** (`import "@react-three/fiber"`): no Canvas binding, DOM intrinsics tagged
- [x] Local Canvas component (not from R3F): tagger does not skip its children
- [x] Sibling `<line>` outside `<Canvas></Canvas>` in same file: tagged
- [x] Plain TS file with type-only fiber imports + JSX: DOM intrinsics tagged

Bundled the package (`pnpm -C packages/vite build`) before testing so the verification ran against the built artifact, not source.

Once this lands and a changesets `version` PR is merged, the App Builder picks up the new `@usehercules/vite` via the next dev-machine bootstrap (the template's `package.json` floats on `^1.0.41`). The customer (`org_01KS1F2AJVDM416NZFNGQAXHH3`) will need their dev workspace restarted once to pick up a fresh dependency install.