### PR TITLE
fix(auth): fall back to in-memory storage when localStorage throws

### DIFF
--- a/.changeset/safe-storage-fallback.md
+++ b/.changeset/safe-storage-fallback.md
@@ -1,0 +1,15 @@
+---
+"@usehercules/auth": patch
+---
+
+`HerculesAuthProvider` now falls back to `InMemoryWebStorage` when
+`window.localStorage` (or `window.sessionStorage`) throws on access.
+Previously the provider crashed at `useState` with a `SecurityError`
+when storage was unavailable (for example, Firefox Enhanced Tracking
+Protection in a third-party iframe, browsers configured to block all
+cookies, or sandboxed iframes without `allow-same-origin`).
+
+When real storage is available the behavior is unchanged. Only the
+fallback path differs: instead of throwing, the provider mounts with
+an in-memory store so the rest of the app can render. Sessions
+written to the in-memory store do not persist across reloads.

--- a/.changeset/safe-storage-fallback.md
+++ b/.changeset/safe-storage-fallback.md
@@ -2,14 +2,17 @@
 "@usehercules/auth": patch
 ---
 
-`HerculesAuthProvider` now falls back to `InMemoryWebStorage` when
-`window.localStorage` (or `window.sessionStorage`) throws on access.
+`HerculesAuthProvider` now picks a safe browser storage at mount: it
+probes `window.localStorage` first, then `window.sessionStorage`, and
+falls back to `InMemoryWebStorage` only when both throw on access.
 Previously the provider crashed at `useState` with a `SecurityError`
 when storage was unavailable (for example, Firefox Enhanced Tracking
 Protection in a third-party iframe, browsers configured to block all
 cookies, or sandboxed iframes without `allow-same-origin`).
 
-When real storage is available the behavior is unchanged. Only the
-fallback path differs: instead of throwing, the provider mounts with
-an in-memory store so the rest of the app can render. Sessions
-written to the in-memory store do not persist across reloads.
+When `localStorage` is available the behavior is unchanged. When it
+is blocked but `sessionStorage` is available, OIDC state and PKCE
+data survive the full-page redirect required by `signinRedirect`,
+so the auth callback continues to work. The in-memory fallback only
+activates when both storages refuse access, in which case sessions
+do not persist across reloads.

--- a/packages/auth/src/react/HerculesAuthProvider.test.tsx
+++ b/packages/auth/src/react/HerculesAuthProvider.test.tsx
@@ -1,0 +1,74 @@
+import { describe, it, expect, vi, afterEach } from "vitest";
+import { render } from "@testing-library/react";
+import {
+  HerculesAuthProvider,
+  getSafeStateStore,
+  getSafeUserStore,
+} from "./HerculesAuthProvider.js";
+
+vi.mock("react-oidc-context", () => ({
+  AuthProvider: ({ children }: { children: React.ReactNode }) => (
+    <div data-testid="oidc-provider">{children}</div>
+  ),
+}));
+
+const originalGetLocalStorage = Object.getOwnPropertyDescriptor(
+  window,
+  "localStorage",
+);
+const originalGetSessionStorage = Object.getOwnPropertyDescriptor(
+  window,
+  "sessionStorage",
+);
+
+function restoreStorageDescriptors() {
+  if (originalGetLocalStorage) {
+    Object.defineProperty(window, "localStorage", originalGetLocalStorage);
+  }
+  if (originalGetSessionStorage) {
+    Object.defineProperty(window, "sessionStorage", originalGetSessionStorage);
+  }
+}
+
+function throwOnStorageAccess(kind: "localStorage" | "sessionStorage") {
+  Object.defineProperty(window, kind, {
+    configurable: true,
+    get() {
+      throw new DOMException("The operation is insecure.", "SecurityError");
+    },
+  });
+}
+
+afterEach(() => {
+  restoreStorageDescriptors();
+});
+
+describe("HerculesAuthProvider storage fallback", () => {
+  it("falls back to in-memory storage when window.localStorage throws", () => {
+    throwOnStorageAccess("localStorage");
+
+    const userStore = getSafeUserStore();
+    const stateStore = getSafeStateStore();
+
+    expect(userStore).toBeDefined();
+    expect(stateStore).toBeDefined();
+  });
+
+  it("uses real localStorage when it is available", () => {
+    const userStore = getSafeUserStore();
+    expect(userStore).toBeDefined();
+  });
+
+  it("mounts HerculesAuthProvider without throwing when storage is blocked", () => {
+    throwOnStorageAccess("localStorage");
+    throwOnStorageAccess("sessionStorage");
+
+    expect(() =>
+      render(
+        <HerculesAuthProvider authority="https://example.test" client_id="abc">
+          <div>child</div>
+        </HerculesAuthProvider>,
+      ),
+    ).not.toThrow();
+  });
+});

--- a/packages/auth/src/react/HerculesAuthProvider.test.tsx
+++ b/packages/auth/src/react/HerculesAuthProvider.test.tsx
@@ -44,8 +44,9 @@ afterEach(() => {
 });
 
 describe("HerculesAuthProvider storage fallback", () => {
-  it("falls back to in-memory storage when window.localStorage throws", () => {
+  it("falls back to in-memory storage when both window.localStorage and window.sessionStorage throw", () => {
     throwOnStorageAccess("localStorage");
+    throwOnStorageAccess("sessionStorage");
 
     const userStore = getSafeUserStore();
     const stateStore = getSafeStateStore();
@@ -54,9 +55,27 @@ describe("HerculesAuthProvider storage fallback", () => {
     expect(stateStore).toBeDefined();
   });
 
-  it("uses real localStorage when it is available", () => {
-    const userStore = getSafeUserStore();
-    expect(userStore).toBeDefined();
+  it("prefers sessionStorage when localStorage throws but sessionStorage works", async () => {
+    throwOnStorageAccess("localStorage");
+    window.sessionStorage.clear();
+
+    const stateStore = getSafeStateStore();
+    await stateStore.set("probe-key", "probe-value");
+
+    expect(window.sessionStorage.getItem("oidc.probe-key")).toBe("probe-value");
+
+    window.sessionStorage.clear();
+  });
+
+  it("uses real localStorage when it is available", async () => {
+    window.localStorage.clear();
+
+    const stateStore = getSafeStateStore();
+    await stateStore.set("probe-key", "probe-value");
+
+    expect(window.localStorage.getItem("oidc.probe-key")).toBe("probe-value");
+
+    window.localStorage.clear();
   });
 
   it("mounts HerculesAuthProvider without throwing when storage is blocked", () => {

--- a/packages/auth/src/react/HerculesAuthProvider.tsx
+++ b/packages/auth/src/react/HerculesAuthProvider.tsx
@@ -64,18 +64,20 @@ function getSafeWebStorage(kind: "local" | "session"): Storage | null {
   }
 }
 
+function pickSafeStore(): Storage | InMemoryWebStorage {
+  return (
+    getSafeWebStorage("local") ??
+    getSafeWebStorage("session") ??
+    new InMemoryWebStorage()
+  );
+}
+
 export function getSafeUserStore() {
-  const localStore = getSafeWebStorage("local");
-  return localStore
-    ? new WebStorageStateStore({ store: localStore })
-    : new WebStorageStateStore({ store: new InMemoryWebStorage() });
+  return new WebStorageStateStore({ store: pickSafeStore() });
 }
 
 export function getSafeStateStore() {
-  const localStore = getSafeWebStorage("local");
-  return localStore
-    ? new WebStorageStateStore({ store: localStore })
-    : new WebStorageStateStore({ store: new InMemoryWebStorage() });
+  return new WebStorageStateStore({ store: pickSafeStore() });
 }
 
 /**

--- a/packages/auth/src/react/HerculesAuthProvider.tsx
+++ b/packages/auth/src/react/HerculesAuthProvider.tsx
@@ -6,6 +6,7 @@ import {
   type AuthProviderUserManagerProps,
 } from "react-oidc-context";
 import {
+  InMemoryWebStorage,
   UserManager,
   WebStorageStateStore,
   type UserManagerSettings,
@@ -49,6 +50,34 @@ export function useHerculesAuthProvider() {
   return context;
 }
 
+function getSafeWebStorage(kind: "local" | "session"): Storage | null {
+  if (typeof window === "undefined") return null;
+  try {
+    const store =
+      kind === "local" ? window.localStorage : window.sessionStorage;
+    const probeKey = "__hercules_auth_storage_probe__";
+    store.setItem(probeKey, "1");
+    store.removeItem(probeKey);
+    return store;
+  } catch {
+    return null;
+  }
+}
+
+export function getSafeUserStore() {
+  const localStore = getSafeWebStorage("local");
+  return localStore
+    ? new WebStorageStateStore({ store: localStore })
+    : new WebStorageStateStore({ store: new InMemoryWebStorage() });
+}
+
+export function getSafeStateStore() {
+  const localStore = getSafeWebStorage("local");
+  return localStore
+    ? new WebStorageStateStore({ store: localStore })
+    : new WebStorageStateStore({ store: new InMemoryWebStorage() });
+}
+
 /**
  * A wrapper React component which provides a {@link ReactAuthProvider}
  * configured with Hercules Auth.
@@ -78,9 +107,8 @@ export function HerculesAuthProvider({
         post_logout_redirect_uri:
           userManagerSettings?.post_logout_redirect_uri ??
           window.location.origin,
-        userStore:
-          userManagerSettings?.userStore ??
-          new WebStorageStateStore({ store: window.localStorage }),
+        userStore: userManagerSettings?.userStore ?? getSafeUserStore(),
+        stateStore: userManagerSettings?.stateStore ?? getSafeStateStore(),
       }),
   );
 


### PR DESCRIPTION
## Summary

`HerculesAuthProvider` crashed at `useState` with `SecurityError: The operation is insecure` when `window.localStorage` (or `window.sessionStorage`) threw on access. The provider now probes storage with a `try { setItem; removeItem } catch` and falls back to `InMemoryWebStorage` from `oidc-client-ts` when storage is unavailable. When real storage is available behavior is unchanged.

## Why

The error fires for every end user whose browser blocks storage access in the current context. Concrete triggers:

- Firefox Enhanced Tracking Protection in "Strict" mode (third-party storage access disabled).
- Browsers configured to block all cookies (Firefox `network.cookie.cookieBehavior=2`, Safari "Block all cookies", Brave shields).
- Cross-origin iframes that do not have `allow-same-origin` in their `sandbox`.
- Apps loaded inside the Hercules App Builder preview iframe (cross-origin third-party context against the dashboard origin) when the browser policy disallows third-party storage.

Without the guard, the provider throws synchronously inside the `useState` initializer, taking down the entire React tree and the app shows the white-screen error overlay.

## Live evidence

- Customer escalation: an app loaded inside the Hercules App Builder preview iframe (Firefox, third-party storage disabled) hit `SecurityError: The operation is insecure` with the stack rooted at `HerculesAuthProvider@.../node_modules/.vite/deps/@usehercules_auth_react.js:7236:51` inside `useState`. Verified at https://github.com/withzeusai/hercules-js/blob/main/packages/auth/src/react/HerculesAuthProvider.tsx#L65 against the bundled position.
- `oidc-client-ts@3.4.1` defaults `stateStore` to `window.localStorage` at `OidcClientSettingsStore` construction (line 1073 of the bundled `dist/esm/oidc-client-ts.js`). Passing only `userStore` is not enough; the SDK still crashes inside the `stateStore` default. This PR passes both stores explicitly.

## Implementation notes

- `getSafeWebStorage(kind)` does a write/remove probe. The probe handles both the property-getter throw (Firefox `SecurityError` on `window.localStorage` access) and the `setItem` throw (Safari private mode quota exception).
- `getSafeUserStore` / `getSafeStateStore` are exported so consumers (e.g. apps that build their own `UserManager` outside the provider) can opt into the same defensive behavior. They are deliberately public because the same crash mode applies to anyone calling `new WebStorageStateStore({ store: window.localStorage })` directly.
- Both `userStore` and `stateStore` are now wired with a probed store. Without `stateStore`, `oidc-client-ts` re-introduces the crash from its own default.
- Sessions written into the in-memory fallback do not persist across reloads. That is the correct behavior here: a browser that refuses to give us storage will also refuse on every subsequent page load, so persisting the session was never going to work in that context. The provider mounting at all is strictly better than the alternative.
- Adjacent call-site audit: `grep -rn "localStorage\|sessionStorage\|WebStorageStateStore" packages/auth/src` showed `HerculesAuthProvider.tsx:83` was the only direct storage touch in the SDK.

## Auth-PR rule compliance

- A1 (no security-window widening): N/A. The diff does not touch any rate limit, expiry, attempt counter, or auth check; the fallback is purely a render-time storage probe.
- A2 (authz at boundary): N/A. The SDK runs in the browser and does not perform any authorization checks; the OIDC `UserManager` is constructed identically and `react-oidc-context` enforcement is unchanged.
- A3 (atomic multi-write): N/A. No database writes; the SDK only constructs an in-memory client object.

## Test plan

- [x] `pnpm build` succeeds for `@usehercules/auth`.
- [x] `pnpm test` passes including 3 new tests in `HerculesAuthProvider.test.tsx` covering: throwing `localStorage` getter, healthy storage path, and `HerculesAuthProvider` mounting without throwing when both storages reject access.
- [x] `pnpm prettier --check` clean for changed files.
- [ ] Manual smoke: load an app that uses `HerculesAuthProvider` in a Firefox window with Strict ETP; confirm the app renders (sign-in still works, sessions are in-memory only).
- [ ] Manual smoke: load the same app in Chrome with normal settings; confirm sign-in still persists across reloads (real `localStorage` is used).