### PR TITLE
feat(convex): scope-admin read queries (members, roles, permissions)

### DIFF
--- a/packages/convex/src/client/index.ts
+++ b/packages/convex/src/client/index.ts
@@ -48,6 +48,8 @@ type GetEffectivePermissionsArgs = {
   resourceId?: string;
 };
 
+type ListScopeArgs = { tokenIdentifier?: string; scopeId: string };
+
 export type RoleSummary = {
   roleId: string;
   roleKey: string;
@@ -79,6 +81,27 @@ export type EffectivePermissionsResult = {
   permissions: string[];
 };
 
+export type ScopeMember = {
+  principalId: string;
+  herculesAuthUserId?: string;
+  status: "active" | "blocked" | "suspended" | "pending_approval";
+  joinedAt: number;
+  name?: string;
+  email?: string;
+  image?: string;
+  roles: RoleSummary[];
+};
+
+export type ScopeRoleSummary = RoleSummary & { shared: boolean };
+
+export type ScopePermissionSummary = {
+  permissionId: string;
+  key: string;
+  resourceType: string;
+  action: string;
+  tenantAssignable: boolean;
+};
+
 export type AccessContext<DataModel extends GenericDataModel = any> =
   | Pick<GenericQueryCtx<DataModel>, "auth" | "runQuery">
   | Pick<GenericMutationCtx<DataModel>, "auth" | "runQuery">
@@ -98,6 +121,14 @@ export type AccessControlComponent = {
       "internal",
       GetEffectivePermissionsArgs,
       EffectivePermissionsResult
+    >;
+    listScopeMembers: FunctionReference<"query", "internal", ListScopeArgs, ScopeMember[]>;
+    listScopeRoles: FunctionReference<"query", "internal", ListScopeArgs, ScopeRoleSummary[]>;
+    listScopePermissions: FunctionReference<
+      "query",
+      "internal",
+      ListScopeArgs,
+      ScopePermissionSummary[]
     >;
   };
 };
@@ -182,14 +213,8 @@ export type AccessControlBuilders<DataModel extends GenericDataModel> = {
   accessQuery: AccessQueryBuilder<DataModel>;
   accessMutation: AccessMutationBuilder<DataModel>;
   accessAction: AccessActionBuilder<DataModel>;
-  hasPermission: (
-    ctx: AccessContext<DataModel>,
-    args: PermissionCheckArgs,
-  ) => Promise<boolean>;
-  requirePermission: (
-    ctx: AccessContext<DataModel>,
-    args: PermissionCheckArgs,
-  ) => Promise<void>;
+  hasPermission: (ctx: AccessContext<DataModel>, args: PermissionCheckArgs) => Promise<boolean>;
+  requirePermission: (ctx: AccessContext<DataModel>, args: PermissionCheckArgs) => Promise<void>;
   requireAnyPermission: (
     ctx: AccessContext<DataModel>,
     args: AnyPermissionCheckArgs,
@@ -199,7 +224,26 @@ export type AccessControlBuilders<DataModel extends GenericDataModel> = {
     args?: EffectivePermissionsArgs,
   ) => Promise<string[]>;
   listMyMemberships: (ctx: AccessContext<DataModel>) => Promise<Membership[]>;
-  listMyRoles: (ctx: AccessContext<DataModel>, args?: { scopeId?: string }) => Promise<RoleSummary[]>;
+  listMyRoles: (
+    ctx: AccessContext<DataModel>,
+    args?: { scopeId?: string },
+  ) => Promise<RoleSummary[]>;
+  // Scope-admin reads for an in-app management screen. Each requires the caller
+  // to hold the matching read permission (system.members:read / system.roles:read
+  // / system.permissions:read) in the scope; otherwise they resolve to an empty
+  // list. Reads come from the local mirror, like every other access query.
+  listScopeMembers: (
+    ctx: AccessContext<DataModel>,
+    args?: { scopeId?: string },
+  ) => Promise<ScopeMember[]>;
+  listScopeRoles: (
+    ctx: AccessContext<DataModel>,
+    args?: { scopeId?: string },
+  ) => Promise<ScopeRoleSummary[]>;
+  listScopePermissions: (
+    ctx: AccessContext<DataModel>,
+    args?: { scopeId?: string },
+  ) => Promise<ScopePermissionSummary[]>;
 };
 
 export type PermissionCheckArgs =
@@ -244,6 +288,9 @@ export function createAccessControl<DataModel extends GenericDataModel>(
     getEffectivePermissions: makeGetEffectivePermissions(component),
     listMyMemberships: makeListMyMemberships(component),
     listMyRoles: makeListMyRoles(component),
+    listScopeMembers: makeListScopeMembers(component),
+    listScopeRoles: makeListScopeRoles(component),
+    listScopePermissions: makeListScopePermissions(component),
   };
 }
 
@@ -369,10 +416,7 @@ function makeAccessBuilder<TBuilder>(
       throw new Error("access* builders require scope to be a function.");
     }
     const { permission, scope, ...convexDefinition } = accessDefinition;
-    const scopeExtractor = (scope ?? defaultScope) as ExtractScope<
-      AuthorizationCtx,
-      unknown
-    >;
+    const scopeExtractor = (scope ?? defaultScope) as ExtractScope<AuthorizationCtx, unknown>;
     return (builder as BuilderCaller)(
       wrapDefinition(convexDefinition, component, "permission", {
         permission,
@@ -413,10 +457,7 @@ type AuthorizationCtx =
   | GenericActionCtx<GenericDataModel>;
 
 function resourceArgs(resource?: AccessResourceRef) {
-  return {
-    resourceType: resource?.type,
-    resourceId: resource?.id,
-  };
+  return { resourceType: resource?.type, resourceId: resource?.id };
 }
 
 async function getTokenIdentifier(ctx: AccessContext): Promise<string | undefined> {
@@ -446,17 +487,11 @@ function normalizeAnyPermissionCheckArgs(args: AnyPermissionCheckArgs) {
 }
 
 function normalizeEffectivePermissionsArgs(args: EffectivePermissionsArgs | undefined) {
-  return {
-    scopeId: args?.scopeId ?? DEFAULT_SCOPE_SENTINEL,
-    resource: args?.resource,
-  };
+  return { scopeId: args?.scopeId ?? DEFAULT_SCOPE_SENTINEL, resource: args?.resource };
 }
 
 function makeHasPermission(component: AccessControlComponent) {
-  return async (
-    ctx: AccessContext,
-    args: PermissionCheckArgs,
-  ): Promise<boolean> => {
+  return async (ctx: AccessContext, args: PermissionCheckArgs): Promise<boolean> => {
     const tokenIdentifier = await getTokenIdentifier(ctx);
     if (!tokenIdentifier) return false;
     const normalized = normalizePermissionCheckArgs(args);
@@ -473,10 +508,7 @@ function makeHasPermission(component: AccessControlComponent) {
 
 function makeRequirePermission(component: AccessControlComponent) {
   const hasPermission = makeHasPermission(component);
-  return async (
-    ctx: AccessContext,
-    args: PermissionCheckArgs,
-  ): Promise<void> => {
+  return async (ctx: AccessContext, args: PermissionCheckArgs): Promise<void> => {
     if (await hasPermission(ctx, args)) return;
     throw new ConvexError({ code: "ACCESS_DENIED", message: "Access denied" });
   };
@@ -484,10 +516,7 @@ function makeRequirePermission(component: AccessControlComponent) {
 
 function makeRequireAnyPermission(component: AccessControlComponent) {
   const hasPermission = makeHasPermission(component);
-  return async (
-    ctx: AccessContext,
-    args: AnyPermissionCheckArgs,
-  ): Promise<void> => {
+  return async (ctx: AccessContext, args: AnyPermissionCheckArgs): Promise<void> => {
     const normalized = normalizeAnyPermissionCheckArgs(args);
     for (const permission of normalized.permissions) {
       if (await hasPermission(ctx, { ...normalized, permission })) return;
@@ -497,10 +526,7 @@ function makeRequireAnyPermission(component: AccessControlComponent) {
 }
 
 function makeGetEffectivePermissions(component: AccessControlComponent) {
-  return async (
-    ctx: AccessContext,
-    args?: EffectivePermissionsArgs,
-  ): Promise<string[]> => {
+  return async (ctx: AccessContext, args?: EffectivePermissionsArgs): Promise<string[]> => {
     const tokenIdentifier = await getTokenIdentifier(ctx);
     if (!tokenIdentifier) return [];
     const normalized = normalizeEffectivePermissionsArgs(args);
@@ -529,6 +555,48 @@ function makeListMyRoles(component: AccessControlComponent) {
     if (!tokenIdentifier) return [];
 
     return await ctx.runQuery(component.queries.listMyRoles, {
+      tokenIdentifier,
+      scopeId: args.scopeId ?? DEFAULT_SCOPE_SENTINEL,
+    });
+  };
+}
+
+function makeListScopeMembers(component: AccessControlComponent) {
+  return async (ctx: AccessContext, args: { scopeId?: string } = {}): Promise<ScopeMember[]> => {
+    const tokenIdentifier = await getTokenIdentifier(ctx);
+    if (!tokenIdentifier) return [];
+
+    return await ctx.runQuery(component.queries.listScopeMembers, {
+      tokenIdentifier,
+      scopeId: args.scopeId ?? DEFAULT_SCOPE_SENTINEL,
+    });
+  };
+}
+
+function makeListScopeRoles(component: AccessControlComponent) {
+  return async (
+    ctx: AccessContext,
+    args: { scopeId?: string } = {},
+  ): Promise<ScopeRoleSummary[]> => {
+    const tokenIdentifier = await getTokenIdentifier(ctx);
+    if (!tokenIdentifier) return [];
+
+    return await ctx.runQuery(component.queries.listScopeRoles, {
+      tokenIdentifier,
+      scopeId: args.scopeId ?? DEFAULT_SCOPE_SENTINEL,
+    });
+  };
+}
+
+function makeListScopePermissions(component: AccessControlComponent) {
+  return async (
+    ctx: AccessContext,
+    args: { scopeId?: string } = {},
+  ): Promise<ScopePermissionSummary[]> => {
+    const tokenIdentifier = await getTokenIdentifier(ctx);
+    if (!tokenIdentifier) return [];
+
+    return await ctx.runQuery(component.queries.listScopePermissions, {
       tokenIdentifier,
       scopeId: args.scopeId ?? DEFAULT_SCOPE_SENTINEL,
     });

--- a/packages/convex/src/component/checks.ts
+++ b/packages/convex/src/component/checks.ts
@@ -48,73 +48,98 @@ export const authorize = query({
       return allow(state?.sourceVersion ?? 0, undefined, []);
     }
 
-    const evaluation = await evaluateEffectiveAccess(ctx, args);
-    if (!evaluation.allowed) {
-      return deny(
-        evaluation.reasonCode,
-        evaluation.sourceVersion,
-        evaluation.principalId,
-        evaluation.effectiveRoleIds,
-      );
-    }
-
-    // Resolve the requested permission's canonical (resourceType, action) by
-    // catalog lookup rather than parsing the key string. The producer ships
-    // the structured columns verbatim, so this works for canonical
-    // (app.appointments:create), dot-action (reports.export), and namespaced
-    // keys alike without the runtime having to agree on slug grammar.
-    // Catalog permissions always live in the default scope (DL15).
-    const resolvedPermission = await findCatalogPermissionByKey(ctx, args.permission);
-    if (!resolvedPermission) {
-      return deny(
-        "permission_missing",
-        evaluation.sourceVersion,
-        evaluation.principalId,
-        evaluation.effectiveRoleIds,
-      );
-    }
-
-    // Requests carry concrete verbs only. A catalog permission whose action is
-    // manage/* would map a request onto a superset token, which the algebra
-    // does not special-case on the request side. Reject rather than evaluate.
-    if (
-      resolvedPermission.action === MANAGE_ACTION ||
-      resolvedPermission.action === WILDCARD_ACTION
-    ) {
-      return deny(
-        "invalid_request",
-        evaluation.sourceVersion,
-        evaluation.principalId,
-        evaluation.effectiveRoleIds,
-      );
-    }
-
-    const decision = evaluateAccess({
-      wildcard: evaluation.wildcard,
-      entries: evaluation.entries,
-      request: {
-        resourceType: resolvedPermission.resourceType,
-        action: resolvedPermission.action,
-        objectId: args.resourceId,
-      },
+    return evaluatePermissionDecision(ctx, {
+      tokenIdentifier: args.tokenIdentifier,
+      scopeId: args.scopeId,
+      permission: args.permission,
+      resourceType: args.resourceType,
+      resourceId: args.resourceId,
     });
+  },
+});
 
-    if (decision === "allow") {
-      return allow(
-        evaluation.sourceVersion ?? 0,
-        evaluation.principalId,
-        evaluation.effectiveRoleIds,
-      );
-    }
-
+/**
+ * Resolve a single permission request to an allow/deny decision. This is the
+ * canonical permission gate, shared by the `authorize` query (the hot can()
+ * path) and the scope-admin list queries, so both apply identical wildcard,
+ * deny-override, and owner-only-lever semantics. Reads only the local mirror.
+ */
+export async function evaluatePermissionDecision(
+  ctx: GenericQueryCtx<DataModel>,
+  args: {
+    tokenIdentifier?: string;
+    scopeId?: string;
+    permission: string;
+    resourceType?: string;
+    resourceId?: string;
+  },
+) {
+  const evaluation = await evaluateEffectiveAccess(ctx, args);
+  if (!evaluation.allowed) {
     return deny(
-      "permission_denied",
+      evaluation.reasonCode,
       evaluation.sourceVersion,
       evaluation.principalId,
       evaluation.effectiveRoleIds,
     );
-  },
-});
+  }
+
+  // Resolve the requested permission's canonical (resourceType, action) by
+  // catalog lookup rather than parsing the key string. The producer ships
+  // the structured columns verbatim, so this works for canonical
+  // (app.appointments:create), dot-action (reports.export), and namespaced
+  // keys alike without the runtime having to agree on slug grammar.
+  // Catalog permissions always live in the default scope (DL15).
+  const resolvedPermission = await findCatalogPermissionByKey(ctx, args.permission);
+  if (!resolvedPermission) {
+    return deny(
+      "permission_missing",
+      evaluation.sourceVersion,
+      evaluation.principalId,
+      evaluation.effectiveRoleIds,
+    );
+  }
+
+  // Requests carry concrete verbs only. A catalog permission whose action is
+  // manage/* would map a request onto a superset token, which the algebra
+  // does not special-case on the request side. Reject rather than evaluate.
+  if (
+    resolvedPermission.action === MANAGE_ACTION ||
+    resolvedPermission.action === WILDCARD_ACTION
+  ) {
+    return deny(
+      "invalid_request",
+      evaluation.sourceVersion,
+      evaluation.principalId,
+      evaluation.effectiveRoleIds,
+    );
+  }
+
+  const decision = evaluateAccess({
+    wildcard: evaluation.wildcard,
+    entries: evaluation.entries,
+    request: {
+      resourceType: resolvedPermission.resourceType,
+      action: resolvedPermission.action,
+      objectId: args.resourceId,
+    },
+  });
+
+  if (decision === "allow") {
+    return allow(
+      evaluation.sourceVersion ?? 0,
+      evaluation.principalId,
+      evaluation.effectiveRoleIds,
+    );
+  }
+
+  return deny(
+    "permission_denied",
+    evaluation.sourceVersion,
+    evaluation.principalId,
+    evaluation.effectiveRoleIds,
+  );
+}
 
 async function findCatalogPermissionByKey(ctx: GenericQueryCtx<DataModel>, key: string) {
   const defaultScope = await ctx.db

--- a/packages/convex/src/component/queries.test.ts
+++ b/packages/convex/src/component/queries.test.ts
@@ -12,6 +12,11 @@ const getEffectivePermissions = makeFunctionReference<"query">(
 );
 const listMyMemberships = makeFunctionReference<"query">("component/queries:listMyMemberships");
 const listMyRoles = makeFunctionReference<"query">("component/queries:listMyRoles");
+const listScopeMembers = makeFunctionReference<"query">("component/queries:listScopeMembers");
+const listScopeRoles = makeFunctionReference<"query">("component/queries:listScopeRoles");
+const listScopePermissions = makeFunctionReference<"query">(
+  "component/queries:listScopePermissions",
+);
 
 const ISSUER = "https://auth.example.com";
 
@@ -242,12 +247,7 @@ describe("listMyMemberships", () => {
     });
 
     expect(roles).toEqual([
-      {
-        roleId: "role_acme_admin",
-        roleKey: "admin",
-        roleName: "Admin",
-        roleKind: "system",
-      },
+      { roleId: "role_acme_admin", roleKey: "admin", roleName: "Admin", roleKind: "system" },
     ]);
   });
 
@@ -424,10 +424,7 @@ describe("getEffectivePermissions", () => {
     // reported by membership; re-evaluating with the permission's own superset
     // action would never match and would drop it.
     expect(result.wildcard).toBe("none");
-    expect(result.permissions).toEqual([
-      "system.access.roles:manage",
-      "system.reports:*",
-    ]);
+    expect(result.permissions).toEqual(["system.access.roles:manage", "system.reports:*"]);
   });
 });
 
@@ -900,3 +897,198 @@ function resourceRoleOrgSnapshot(): AccessProjectionSnapshot {
     },
   };
 }
+
+describe("scope admin reads", () => {
+  // Default scope with the system read permissions in the catalog, an Owner
+  // (immutable wildcard, so it passes any read gate), and a plain Member
+  // (no permissions). The catalog must contain the gated key or the gate
+  // denies, so the read permissions are seeded explicitly.
+  function adminReadSnapshot(): AccessProjectionSnapshot {
+    return {
+      type: "access.projection.snapshot",
+      schemaVersion: 2,
+      eventId: "evt_admin_read",
+      sourceVersion: 1,
+      expectedIssuer: ISSUER,
+      scope: {
+        accessScopeId: "scope_default",
+        name: "Default",
+        kind: "default",
+        status: "active",
+        accountEntryMode: "open",
+        defaultRoleId: "role_member",
+        updatedAt: 1,
+      },
+      entities: {
+        ...emptyEntities(),
+        users: [
+          {
+            herculesAuthUserId: "user_owner",
+            name: "Olivia Owner",
+            email: "olivia@example.com",
+            emailVerified: true,
+            phoneVerified: false,
+            updatedAt: 1,
+          },
+          {
+            herculesAuthUserId: "user_member",
+            name: "Mia Member",
+            email: "mia@example.com",
+            emailVerified: true,
+            phoneVerified: false,
+            updatedAt: 1,
+          },
+        ],
+        permissions: [
+          {
+            permissionId: "perm_members_read",
+            accessScopeId: "scope_default",
+            key: "system.members:read",
+            resourceType: "system.members",
+            action: "read",
+            tenantAssignable: false,
+            updatedAt: 1,
+          },
+          {
+            permissionId: "perm_roles_read",
+            accessScopeId: "scope_default",
+            key: "system.roles:read",
+            resourceType: "system.roles",
+            action: "read",
+            tenantAssignable: false,
+            updatedAt: 1,
+          },
+          {
+            permissionId: "perm_permissions_read",
+            accessScopeId: "scope_default",
+            key: "system.permissions:read",
+            resourceType: "system.permissions",
+            action: "read",
+            tenantAssignable: false,
+            updatedAt: 1,
+          },
+          {
+            permissionId: "perm_posts_read",
+            accessScopeId: "scope_default",
+            key: "posts:read",
+            resourceType: "posts",
+            action: "read",
+            tenantAssignable: true,
+            updatedAt: 1,
+          },
+        ],
+        roles: [
+          {
+            roleId: "role_owner",
+            accessScopeId: "scope_default",
+            key: "owner",
+            kind: "system",
+            name: "Owner",
+            wildcard: "immutable",
+            updatedAt: 1,
+          },
+          {
+            roleId: "role_member",
+            accessScopeId: "scope_default",
+            key: "member",
+            kind: "system",
+            name: "Member",
+            wildcard: "none",
+            updatedAt: 1,
+          },
+        ],
+        principals: [
+          {
+            principalId: "p_owner",
+            type: "user",
+            herculesAuthUserId: "user_owner",
+            status: "active",
+            joinedAt: 1001,
+            updatedAt: 1001,
+          },
+          {
+            principalId: "p_member",
+            type: "user",
+            herculesAuthUserId: "user_member",
+            status: "active",
+            joinedAt: 1002,
+            updatedAt: 1002,
+          },
+        ],
+        grants: [
+          {
+            grantId: "grant_owner",
+            subjectPrincipalId: "p_owner",
+            relationKind: "role",
+            roleId: "role_owner",
+            effect: "allow",
+            objectType: "scope",
+            objectId: "scope_default",
+            updatedAt: 1,
+          },
+          {
+            grantId: "grant_member",
+            subjectPrincipalId: "p_member",
+            relationKind: "role",
+            roleId: "role_member",
+            effect: "allow",
+            objectType: "scope",
+            objectId: "scope_default",
+            updatedAt: 1,
+          },
+        ],
+      },
+    };
+  }
+
+  test("owner lists members with roles; unprivileged member gets an empty list", async () => {
+    const t = convexTest(schema, modules);
+    await t.mutation(applySync, adminReadSnapshot());
+
+    const asOwner = await t.query(listScopeMembers, {
+      tokenIdentifier: `${ISSUER}|user_owner`,
+      scopeId: "scope_default",
+    });
+    expect(asOwner.map((m) => m.herculesAuthUserId).sort()).toEqual(["user_member", "user_owner"]);
+    const owner = asOwner.find((m) => m.herculesAuthUserId === "user_owner");
+    expect(owner?.name).toBe("Olivia Owner");
+    expect(owner?.roles[0]?.roleKey).toBe("owner");
+
+    const asMember = await t.query(listScopeMembers, {
+      tokenIdentifier: `${ISSUER}|user_member`,
+      scopeId: "scope_default",
+    });
+    expect(asMember).toEqual([]);
+  });
+
+  test("owner lists roles and the permission catalog; member is denied both", async () => {
+    const t = convexTest(schema, modules);
+    await t.mutation(applySync, adminReadSnapshot());
+
+    const roles = await t.query(listScopeRoles, {
+      tokenIdentifier: `${ISSUER}|user_owner`,
+      scopeId: "scope_default",
+    });
+    expect(roles.map((r) => r.roleKey).sort()).toEqual(["member", "owner"]);
+
+    const permissions = await t.query(listScopePermissions, {
+      tokenIdentifier: `${ISSUER}|user_owner`,
+      scopeId: "scope_default",
+    });
+    expect(permissions.map((p) => p.key)).toContain("posts:read");
+    expect(permissions.map((p) => p.key)).toContain("system.members:read");
+
+    expect(
+      await t.query(listScopeRoles, {
+        tokenIdentifier: `${ISSUER}|user_member`,
+        scopeId: "scope_default",
+      }),
+    ).toEqual([]);
+    expect(
+      await t.query(listScopePermissions, {
+        tokenIdentifier: `${ISSUER}|user_member`,
+        scopeId: "scope_default",
+      }),
+    ).toEqual([]);
+  });
+});

--- a/packages/convex/src/component/queries.ts
+++ b/packages/convex/src/component/queries.ts
@@ -5,8 +5,11 @@ import {
   type QueryBuilder,
 } from "convex/server";
 import { v } from "convex/values";
+import { evaluatePermissionDecision } from "./checks";
 import { enumeratePermissions, evaluateEffectiveAccess } from "./effective";
 import schema from "./schema";
+
+const DEFAULT_SCOPE_SENTINEL = "__hercules_default_scope__";
 
 type DataModel = DataModelFromSchemaDefinition<typeof schema>;
 const query = queryGeneric as QueryBuilder<DataModel, "public">;
@@ -42,6 +45,31 @@ type EffectivePermissionsResult = {
   // and avoid treating the materialized list as exhaustive.
   wildcard: "none" | "immutable" | "default";
   permissions: string[];
+};
+
+type ScopeMember = {
+  principalId: string;
+  herculesAuthUserId?: string;
+  status: "active" | "blocked" | "suspended" | "pending_approval";
+  joinedAt: number;
+  name?: string;
+  email?: string;
+  image?: string;
+  roles: RoleSummary[];
+};
+
+type ScopeRoleSummary = RoleSummary & {
+  // True when the role is an app-wide shared role (default scope) surfaced as
+  // assignable inside an org scope, rather than a role owned by this scope.
+  shared: boolean;
+};
+
+type ScopePermissionSummary = {
+  permissionId: string;
+  key: string;
+  resourceType: string;
+  action: string;
+  tenantAssignable: boolean;
 };
 
 export const listMyMemberships = query({
@@ -91,10 +119,7 @@ export const listMyMemberships = query({
 });
 
 export const listMyRoles = query({
-  args: {
-    tokenIdentifier: v.optional(v.string()),
-    scopeId: v.string(),
-  },
+  args: { tokenIdentifier: v.optional(v.string()), scopeId: v.string() },
   handler: async (ctx, args): Promise<RoleSummary[]> => {
     if (!args.tokenIdentifier) return [];
 
@@ -152,6 +177,172 @@ export const getEffectivePermissions = query({
     };
   },
 });
+
+export const listScopeMembers = query({
+  args: { tokenIdentifier: v.optional(v.string()), scopeId: v.string() },
+  handler: async (ctx, args): Promise<ScopeMember[]> => {
+    if (!(await callerHasScopePermission(ctx, args, "system.members:read"))) return [];
+    const scope = await resolveScopeRow(ctx, args.scopeId);
+    if (!scope) return [];
+
+    const principals = await ctx.db
+      .query("principals")
+      .withIndex("by_scope_type", (q) =>
+        q.eq("accessScopeId", scope.accessScopeId).eq("type", "user"),
+      )
+      .collect();
+
+    const members: ScopeMember[] = [];
+    for (const principal of principals) {
+      let name: string | undefined;
+      let email: string | undefined;
+      let image: string | undefined;
+      const authUserId = principal.herculesAuthUserId;
+      if (authUserId) {
+        const user = await ctx.db
+          .query("users")
+          .withIndex("by_auth_user_id", (q) => q.eq("herculesAuthUserId", authUserId))
+          .unique();
+        if (user) {
+          name = user.name;
+          email = user.email;
+          image = user.image;
+        }
+      }
+      const roles = await collectPrincipalScopeRoles(ctx, {
+        principalId: principal.principalId,
+        scopeId: scope.accessScopeId,
+      });
+      members.push({
+        principalId: principal.principalId,
+        herculesAuthUserId: authUserId,
+        status: principal.status,
+        joinedAt: principal.joinedAt,
+        name,
+        email,
+        image,
+        roles,
+      });
+    }
+
+    members.sort((a, b) =>
+      (a.name ?? a.email ?? a.principalId).localeCompare(b.name ?? b.email ?? b.principalId),
+    );
+    return members;
+  },
+});
+
+export const listScopeRoles = query({
+  args: { tokenIdentifier: v.optional(v.string()), scopeId: v.string() },
+  handler: async (ctx, args): Promise<ScopeRoleSummary[]> => {
+    if (!(await callerHasScopePermission(ctx, args, "system.roles:read"))) return [];
+    const scope = await resolveScopeRow(ctx, args.scopeId);
+    if (!scope) return [];
+
+    const defaultScope = await ctx.db
+      .query("scopes")
+      .withIndex("by_kind", (q) => q.eq("kind", "default"))
+      .unique();
+    const defaultScopeId = defaultScope?.accessScopeId;
+
+    const scopeRoles = await ctx.db
+      .query("roles")
+      .withIndex("by_scope", (q) => q.eq("accessScopeId", scope.accessScopeId))
+      .collect();
+    // Shared/app-wide roles (default scope) are assignable inside any org scope,
+    // so surface them alongside the scope's own roles when viewing an org.
+    const sharedRoles =
+      defaultScopeId && defaultScopeId !== scope.accessScopeId
+        ? await ctx.db
+            .query("roles")
+            .withIndex("by_scope", (q) => q.eq("accessScopeId", defaultScopeId))
+            .collect()
+        : [];
+
+    const seen = new Set<string>();
+    const roles: ScopeRoleSummary[] = [];
+    for (const role of [...scopeRoles, ...sharedRoles]) {
+      if (seen.has(role.roleId)) continue;
+      seen.add(role.roleId);
+      roles.push({
+        roleId: role.roleId,
+        roleKey: role.key,
+        roleName: role.name,
+        roleKind: role.kind,
+        shared:
+          defaultScopeId !== undefined &&
+          role.accessScopeId === defaultScopeId &&
+          defaultScopeId !== scope.accessScopeId,
+      });
+    }
+
+    roles.sort(
+      (a, b) =>
+        a.roleKey.localeCompare(b.roleKey) ||
+        a.roleName.localeCompare(b.roleName) ||
+        a.roleId.localeCompare(b.roleId),
+    );
+    return roles;
+  },
+});
+
+export const listScopePermissions = query({
+  args: { tokenIdentifier: v.optional(v.string()), scopeId: v.string() },
+  handler: async (ctx, args): Promise<ScopePermissionSummary[]> => {
+    if (!(await callerHasScopePermission(ctx, args, "system.permissions:read"))) return [];
+    // The permission catalog is app-wide and always lives in the default scope (DL15).
+    const defaultScope = await ctx.db
+      .query("scopes")
+      .withIndex("by_kind", (q) => q.eq("kind", "default"))
+      .unique();
+    if (!defaultScope) return [];
+
+    const permissions = await ctx.db
+      .query("permissions")
+      .withIndex("by_scope", (q) => q.eq("accessScopeId", defaultScope.accessScopeId))
+      .collect();
+
+    return permissions
+      .map((permission) => ({
+        permissionId: permission.permissionId,
+        key: permission.key,
+        resourceType: permission.resourceType,
+        action: permission.action,
+        tenantAssignable: permission.tenantAssignable,
+      }))
+      .sort((a, b) => a.key.localeCompare(b.key) || a.permissionId.localeCompare(b.permissionId));
+  },
+});
+
+// Scope-admin reads share the canonical permission gate with authorize(), so an
+// in-app admin screen and a can() check resolve identically (wildcard,
+// deny-override, owner-only levers). Returns false when not allowed, and the
+// queries above then return an empty list.
+async function callerHasScopePermission(
+  ctx: GenericQueryCtx<DataModel>,
+  args: { tokenIdentifier?: string; scopeId: string },
+  permission: string,
+): Promise<boolean> {
+  const decision = await evaluatePermissionDecision(ctx, {
+    tokenIdentifier: args.tokenIdentifier,
+    scopeId: args.scopeId,
+    permission,
+  });
+  return decision.allowed;
+}
+
+async function resolveScopeRow(ctx: GenericQueryCtx<DataModel>, scopeId: string) {
+  if (scopeId === DEFAULT_SCOPE_SENTINEL) {
+    return await ctx.db
+      .query("scopes")
+      .withIndex("by_kind", (q) => q.eq("kind", "default"))
+      .unique();
+  }
+  return await ctx.db
+    .query("scopes")
+    .withIndex("by_scope_id", (q) => q.eq("accessScopeId", scopeId))
+    .unique();
+}
 
 function parseTokenIdentifier(tokenIdentifier: string) {
   const separatorIndex = tokenIdentifier.lastIndexOf("|");


### PR DESCRIPTION
Adds the scope-wide read queries an app needs to build its own in-app admin screen (list everyone in a scope, list all roles, list the permission catalog). Today the component only exposes caller-scoped reads (`listMyRoles`, `getEffectivePermissions`), so an app builder following the `access-control-admin-dashboard` guide had no way to render a members/roles list. This fills that gap from the local mirror - no new HTTP/GET on the control plane.

## What
New component queries + client wrappers:
- `listScopeMembers(scopeId?)` -> members (with resolved name/email/image + their roles + status)
- `listScopeRoles(scopeId?)` -> roles in the scope plus assignable shared roles (with a `shared` flag)
- `listScopePermissions(scopeId?)` -> the app-wide permission catalog

## Gating (security)
Each query is gated by the matching read permission - `system.members:read`, `system.roles:read`, `system.permissions:read` - via a **shared permission gate (`evaluatePermissionDecision`) extracted from `authorize()`**. So an in-app admin screen and a `can()` check resolve permissions identically (wildcard / deny-override / owner-only levers), with no duplicated security logic. Unauthorized callers get an empty list. All reads come from the local Convex mirror, like every other access query.

## Tests
- New gate tests: an Owner lists members/roles/permissions; an unprivileged member is denied (empty) for all three.
- `authorize` behavior is unchanged - `checks.test.ts` (24 tests) still green after the extraction.
- Full suite: 117 tests pass; `tsc` build clean.

Base: `feat/access-control-v1` (the integration branch for the access-control component).

🤖 Generated with [Claude Code](https://claude.com/claude-code)